### PR TITLE
Fixes PHP Parse error:  syntax error, unexpected ')'

### DIFF
--- a/dev/slugs/admin/qtx_admin_slug.php
+++ b/dev/slugs/admin/qtx_admin_slug.php
@@ -51,7 +51,7 @@ function qtranxf_regroup_translations_for( $type, $edit_lang, $default_lang ) {
 }// */
 
 function qtranxf_slug_collect_translations_posted() {
-	if(isset($_REQUEST['qtranslate-slugs']))){
+	if(isset($_REQUEST['qtranslate-slugs'])){
 		//ensure REQUEST has the value of the default language
 		//multilingual slug/term values will be processed later
 		$edit_lang = qtranxf_getLanguageEdit();


### PR DESCRIPTION
Since it's in the dev folder, this file probably doesn't actually get accessed -- I found this when running a script to preload opcache, which compiles every php file on my system. But hey I thought I'd send in a fix anyway! :smile: