### PR TITLE
Fix no redirect allowed on API REST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 3.5.2
+* Add admin notice for WP5.0: "Gutenberg" block editor not supported, install Classic Editor plugin.
+* Fix unresolved variables and unused PHP syntax error in dev code.
+* Fix deprecated jQuery.ready JS handler, refactor jQuery wrapper/closure functions and standard coding style.
+
 ### 3.5.1
 * Cleanup: reformat all PHP code with WordPress coding style, remove lots of commented code for better clarity. Breathe again!
 * Redesign admin Language Switching Buttons (built-in LSB styles) and 'Copy From' button with new ergonomics.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ See [original plugin](https://wordpress.org/plugins/qtranslate-x/).
 
 Check the CHANGELOG.md for the full history.
 
+### 3.5.2
+* Add admin notice for WP5.0: "Gutenberg" block editor not supported, install Classic Editor plugin.
+* Fix unresolved variables and unused PHP syntax error in dev code.
+* Fix deprecated jQuery.ready JS handler, refactor jQuery wrapper/closure functions and standard coding style.
+
 ### 3.5.1
 * Cleanup: reformat all PHP code with WordPress coding style, remove lots of commented code for better clarity. Breathe again!
 * Redesign admin Language Switching Buttons (built-in LSB styles) and 'Copy From' button with new ergonomics.
@@ -127,4 +132,5 @@ The [legacy issues](https://qtranslatexteam.wordpress.com/known-issues/) should 
 * support for Gutenberg (!!)
 * support for translatable slugs (!)
 * support for WooCommerce (revive the add-on!)
+* unit/integration tests
 * legacy of [desirable features](https://qtranslatexteam.wordpress.com/desirable/).

--- a/qtranslate.php
+++ b/qtranslate.php
@@ -3,7 +3,7 @@
  * Plugin Name: qTranslate-XT
  * Plugin URI: http://github.com/qtranslate/qtranslate-xt/
  * Description: Adds user-friendly and database-friendly multilingual content support.
- * Version: 3.5.1
+ * Version: 3.5.2
  * Author: qTranslate Community
  * Author URI: http://github.com/qtranslate/
  * Tags: multilingual, multi, language, admin, tinymce, Polyglot, bilingual, widget, switcher, professional, human, translation, service, qTranslate, zTranslate, mqTranslate, qTranslate Plus, WPML
@@ -54,7 +54,7 @@ if ( ! function_exists( 'add_filter' ) ) {
  * Designed as interface for other plugin integration. The documentation is available at
  * https://qtranslatexteam.wordpress.com/integration/
  */
-define( 'QTX_VERSION', '3.5.1.1' );
+define( 'QTX_VERSION', '3.5.2' );
 
 if ( ! defined( 'QTRANSLATE_FILE' ) ) {
 	define( 'QTRANSLATE_FILE', __FILE__ );

--- a/qtranslate_core.php
+++ b/qtranslate_core.php
@@ -170,17 +170,18 @@ function qtranxf_detect_language( &$url_info ) {
 
 	$lang = qtranxf_parse_language_info( $url_info );
 
-  if ( qtranxf_is_rest_request_expected() ) {
-    if ( ! isset( $lang ) ) {
-      $lang = $q_config['default_language'];
-    }
-    $url_info['language'] = $lang;
-    return $lang;
-  }
+	if ( qtranxf_is_rest_request_expected() ) {
+		if ( ! isset( $lang ) ) {
+			$lang = $q_config['default_language'];
+		}
+		$url_info['language'] = $lang;
+
+		return $lang;
+	}
 
 	if ( ( ! $lang || ! isset( $url_info['doing_front_end'] ) )
-	     && ( defined( 'DOING_AJAX' ) || ! $url_info['cookie_enabled'] )
-	     && isset( $_SERVER['HTTP_REFERER'] )
+			 && ( defined( 'DOING_AJAX' ) || ! $url_info['cookie_enabled'] )
+			 && isset( $_SERVER['HTTP_REFERER'] )
 	) {
 		//get language from HTTP_REFERER, if needed, and detect front- vs back-end
 		$http_referer             = $_SERVER['HTTP_REFERER'];
@@ -211,7 +212,7 @@ function qtranxf_detect_language( &$url_info ) {
 				}
 			}
 			if ( ! $lang && $q_config['hide_default_language']
-			     && isset( $url_info['doing_front_end'] ) && $url_info['doing_front_end'] ) {
+					 && isset( $url_info['doing_front_end'] ) && $url_info['doing_front_end'] ) {
 				$lang = $q_config['default_language'];
 			}
 		}
@@ -421,8 +422,8 @@ function qtranxf_detect_language_front( &$url_info ) {
 		}
 
 		if ( $q_config['detect_browser_language']
-		     && ( ! isset( $_SERVER['HTTP_REFERER'] ) || strpos( $_SERVER['HTTP_REFERER'], $url_info['host'] ) === false )//external referrer or no referrer
-		     && ( empty( $url_info['wp-path'] ) || $url_info['wp-path'] == '/' )// home page is requested
+				 && ( ! isset( $_SERVER['HTTP_REFERER'] ) || strpos( $_SERVER['HTTP_REFERER'], $url_info['host'] ) === false )//external referrer or no referrer
+				 && ( empty( $url_info['wp-path'] ) || $url_info['wp-path'] == '/' )// home page is requested
 		) {
 			$lang                     = qtranxf_http_negotiate_language();
 			$url_info['lang_browser'] = $lang;
@@ -435,7 +436,7 @@ function qtranxf_detect_language_front( &$url_info ) {
 		break;
 	}
 	if ( ! isset( $url_info['doredirect'] )
-	     && ( ! $q_config['hide_default_language'] || $lang != $q_config['default_language'] )
+			 && ( ! $q_config['hide_default_language'] || $lang != $q_config['default_language'] )
 		//&& !$url_info['language_neutral_path']//already so
 	) {
 		$url_info['doredirect'] = 'language needs to be shown in url';
@@ -1146,12 +1147,12 @@ function qtranxf_url_set_language( $urlinfo, $lang, $showLanguage ) {
 
 	// see if cookies are activated
 	if ( ! $showLanguage//there still is no language information in the converted URL
-	     && ! $q_config['url_info']['cookie_enabled']// there will be no way to take language from the cookie
-	     //&& empty($urlinfo['path']) //why this was here?
-	     //&& !isset($q_config['url_info']['internal_referer'])//three below replace this one?
-	     && $q_config['language'] != $q_config['default_language']//we need to be able to get language other than default
-	     && empty( $q_config['url_info']['lang_url'] )//we will not be able to get language from referrer path
-	     && empty( $q_config['url_info']['lang_query_get'] )//we will not be able to get language from referrer query
+			 && ! $q_config['url_info']['cookie_enabled']// there will be no way to take language from the cookie
+			 //&& empty($urlinfo['path']) //why this was here?
+			 //&& !isset($q_config['url_info']['internal_referer'])//three below replace this one?
+			 && $q_config['language'] != $q_config['default_language']//we need to be able to get language other than default
+			 && empty( $q_config['url_info']['lang_url'] )//we will not be able to get language from referrer path
+			 && empty( $q_config['url_info']['lang_query_get'] )//we will not be able to get language from referrer query
 	) {
 		// :( now we have to make unpretty URLs
 		qtranxf_add_query_arg( $urlinfo['query'], 'lang=' . $lang );
@@ -1824,3 +1825,32 @@ function qtranxf_showAllSeparated( $text ) {
 
 	return $result;
 }
+
+/**
+ * Add specific rewrites to handle API REST for the default language, when hidden in QTX_URL_PATH mode.
+ * Most of the requests don't need this, as they are handled through custom home_url with the language.
+ * Note: to make it work you have to flush your rewrite rules by saving the permalink structures from the admin page!
+ *
+ * Example with 'en' as default language and hidden option enabled:
+ *   /wp-json/wp/...    -> home_url = '/' (default, hidden)
+ *   /fr/wp-json/wp/... -> home_url = '/fr'
+ *   /en/wp-json/wp/... -> home_url = '/' (default, hidden but requested) -> fails with standard rewrites (404)
+ * This function allows to handle specifically this last case.
+ *
+ * @see rest_api_register_rewrites in wp_includes/rest-api.php
+ */
+function qtranxf_rest_api_register_rewrites() {
+	global $q_config;
+	if ( ! $q_config['hide_default_language'] || $q_config['url_mode'] !== QTX_URL_PATH ) {
+		return;
+	}
+
+	global $wp_rewrite;
+	$default_lang = $q_config['default_language'];
+	add_rewrite_rule( '^' . $default_lang . '/' . rest_get_url_prefix() . '/?$', 'index.php?rest_route=/', 'top' );
+	add_rewrite_rule( '^' . $default_lang . '/' . rest_get_url_prefix() . '/(.*)?', 'index.php?rest_route=/$matches[1]', 'top' );
+	add_rewrite_rule( '^' . $default_lang . '/' . $wp_rewrite->index . '/' . rest_get_url_prefix() . '/?$', 'index.php?rest_route=/', 'top' );
+	add_rewrite_rule( '^' . $default_lang . '/' . $wp_rewrite->index . '/' . rest_get_url_prefix() . '/(.*)?', 'index.php?rest_route=/$matches[1]', 'top' );
+}
+
+add_action( 'init', 'qtranxf_rest_api_register_rewrites', 11 );

--- a/qtranslate_core.php
+++ b/qtranslate_core.php
@@ -170,6 +170,14 @@ function qtranxf_detect_language( &$url_info ) {
 
 	$lang = qtranxf_parse_language_info( $url_info );
 
+  if ( qtranxf_is_rest_request_expected() ) {
+    if ( ! isset( $lang ) ) {
+      $lang = $q_config['default_language'];
+    }
+    $url_info['language'] = $lang;
+    return $lang;
+  }
+
 	if ( ( ! $lang || ! isset( $url_info['doing_front_end'] ) )
 	     && ( defined( 'DOING_AJAX' ) || ! $url_info['cookie_enabled'] )
 	     && isset( $_SERVER['HTTP_REFERER'] )

--- a/qtranslate_core.php
+++ b/qtranslate_core.php
@@ -170,6 +170,7 @@ function qtranxf_detect_language( &$url_info ) {
 
 	$lang = qtranxf_parse_language_info( $url_info );
 
+	// REST calls should be deterministic (stateless), no special language detection e.g. based on cookie
 	if ( qtranxf_is_rest_request_expected() ) {
 		if ( ! isset( $lang ) ) {
 			$lang = $q_config['default_language'];
@@ -180,8 +181,8 @@ function qtranxf_detect_language( &$url_info ) {
 	}
 
 	if ( ( ! $lang || ! isset( $url_info['doing_front_end'] ) )
-			 && ( defined( 'DOING_AJAX' ) || ! $url_info['cookie_enabled'] )
-			 && isset( $_SERVER['HTTP_REFERER'] )
+		 && ( defined( 'DOING_AJAX' ) || ! $url_info['cookie_enabled'] )
+		 && isset( $_SERVER['HTTP_REFERER'] )
 	) {
 		//get language from HTTP_REFERER, if needed, and detect front- vs back-end
 		$http_referer             = $_SERVER['HTTP_REFERER'];
@@ -212,7 +213,7 @@ function qtranxf_detect_language( &$url_info ) {
 				}
 			}
 			if ( ! $lang && $q_config['hide_default_language']
-					 && isset( $url_info['doing_front_end'] ) && $url_info['doing_front_end'] ) {
+				 && isset( $url_info['doing_front_end'] ) && $url_info['doing_front_end'] ) {
 				$lang = $q_config['default_language'];
 			}
 		}
@@ -422,8 +423,8 @@ function qtranxf_detect_language_front( &$url_info ) {
 		}
 
 		if ( $q_config['detect_browser_language']
-				 && ( ! isset( $_SERVER['HTTP_REFERER'] ) || strpos( $_SERVER['HTTP_REFERER'], $url_info['host'] ) === false )//external referrer or no referrer
-				 && ( empty( $url_info['wp-path'] ) || $url_info['wp-path'] == '/' )// home page is requested
+			 && ( ! isset( $_SERVER['HTTP_REFERER'] ) || strpos( $_SERVER['HTTP_REFERER'], $url_info['host'] ) === false )//external referrer or no referrer
+			 && ( empty( $url_info['wp-path'] ) || $url_info['wp-path'] == '/' )// home page is requested
 		) {
 			$lang                     = qtranxf_http_negotiate_language();
 			$url_info['lang_browser'] = $lang;
@@ -436,7 +437,7 @@ function qtranxf_detect_language_front( &$url_info ) {
 		break;
 	}
 	if ( ! isset( $url_info['doredirect'] )
-			 && ( ! $q_config['hide_default_language'] || $lang != $q_config['default_language'] )
+		 && ( ! $q_config['hide_default_language'] || $lang != $q_config['default_language'] )
 		//&& !$url_info['language_neutral_path']//already so
 	) {
 		$url_info['doredirect'] = 'language needs to be shown in url';
@@ -1147,12 +1148,12 @@ function qtranxf_url_set_language( $urlinfo, $lang, $showLanguage ) {
 
 	// see if cookies are activated
 	if ( ! $showLanguage//there still is no language information in the converted URL
-			 && ! $q_config['url_info']['cookie_enabled']// there will be no way to take language from the cookie
-			 //&& empty($urlinfo['path']) //why this was here?
-			 //&& !isset($q_config['url_info']['internal_referer'])//three below replace this one?
-			 && $q_config['language'] != $q_config['default_language']//we need to be able to get language other than default
-			 && empty( $q_config['url_info']['lang_url'] )//we will not be able to get language from referrer path
-			 && empty( $q_config['url_info']['lang_query_get'] )//we will not be able to get language from referrer query
+		 && ! $q_config['url_info']['cookie_enabled']// there will be no way to take language from the cookie
+		 //&& empty($urlinfo['path']) //why this was here?
+		 //&& !isset($q_config['url_info']['internal_referer'])//three below replace this one?
+		 && $q_config['language'] != $q_config['default_language']//we need to be able to get language other than default
+		 && empty( $q_config['url_info']['lang_url'] )//we will not be able to get language from referrer path
+		 && empty( $q_config['url_info']['lang_query_get'] )//we will not be able to get language from referrer query
 	) {
 		// :( now we have to make unpretty URLs
 		qtranxf_add_query_arg( $urlinfo['query'], 'lang=' . $lang );

--- a/qtranslate_utils.php
+++ b/qtranslate_utils.php
@@ -837,8 +837,18 @@ function qtranxf_getSortedLanguages( $reverse = false ) {
 	return $clean_languages;
 }
 
+/**
+ * Evaluates if the request URI leads to a REST request.
+ * This is only a prediction based on REST prefix, but no strict guarantee the REST request will be processed.
+ * @return bool
+ */
+function qtranxf_is_rest_request_expected() {
+  return stripos( $_SERVER['REQUEST_URI'], '/' . rest_get_url_prefix() . '/' ) !== false;
+}
+
 function qtranxf_can_redirect() {
 	return ! defined( 'WP_ADMIN' ) && ! defined( 'DOING_AJAX' ) && ! defined( 'WP_CLI' ) && ! defined( 'DOING_CRON' ) && empty( $_POST )
+         && ( ! qtranxf_is_rest_request_expected() )
 	       //'REDIRECT_*' needs more testing
 	       //&& !isset($_SERVER['REDIRECT_URL'])
 	       && ( ! isset( $_SERVER['REDIRECT_STATUS'] ) || $_SERVER['REDIRECT_STATUS'] == '200' );

--- a/qtranslate_utils.php
+++ b/qtranslate_utils.php
@@ -838,20 +838,29 @@ function qtranxf_getSortedLanguages( $reverse = false ) {
 }
 
 /**
- * Evaluates if the request URI leads to a REST request.
- * This is only a prediction based on REST prefix, but no strict guarantee the REST request will be processed.
+ * Evaluate if the request URI leads to a REST call.
+ * This is only a prediction based on REST prefix, but no strict guarantee the REST request will be processed as such.
+ *
+ * @see rest_api_register_rewrites in wp_includes/rest-api.php for the REST rewrite rules using query_var = rest_route
+ * @see parse_request in wp_includes/class-wp.php for the final processing of REQUEST_URI
  * @return bool
  */
 function qtranxf_is_rest_request_expected() {
-  return stripos( $_SERVER['REQUEST_URI'], '/' . rest_get_url_prefix() . '/' ) !== false;
+	return stripos( $_SERVER['REQUEST_URI'], '/' . rest_get_url_prefix() . '/' ) !== false;
 }
 
+/**
+ * Evaluate if the current request allows HTTP redirection.
+ * Admin requests (WP_ADMIN, DOING_AJAX, WP_CLI, DOING_CRON) or REST calls should not be redirected.
+ *
+ * @return bool
+ */
 function qtranxf_can_redirect() {
 	return ! defined( 'WP_ADMIN' ) && ! defined( 'DOING_AJAX' ) && ! defined( 'WP_CLI' ) && ! defined( 'DOING_CRON' ) && empty( $_POST )
-         && ( ! qtranxf_is_rest_request_expected() )
-	       //'REDIRECT_*' needs more testing
-	       //&& !isset($_SERVER['REDIRECT_URL'])
-	       && ( ! isset( $_SERVER['REDIRECT_STATUS'] ) || $_SERVER['REDIRECT_STATUS'] == '200' );
+		   && ( ! qtranxf_is_rest_request_expected() )
+		   //'REDIRECT_*' needs more testing
+		   //&& !isset($_SERVER['REDIRECT_URL'])
+		   && ( ! isset( $_SERVER['REDIRECT_STATUS'] ) || $_SERVER['REDIRECT_STATUS'] == '200' );
 }
 
 /**

--- a/readme.txt
+++ b/readme.txt
@@ -76,6 +76,11 @@ See [original plugin](https://wordpress.org/plugins/qtranslate-x/).
 
 Check the CHANGELOG.md for the full history.
 
+### 3.5.2
+* Add admin notice for WP5.0: "Gutenberg" block editor not supported, install Classic Editor plugin.
+* Fix unresolved variables and unused PHP syntax error in dev code.
+* Fix deprecated jQuery.ready JS handler, refactor jQuery wrapper/closure functions and standard coding style.
+
 ### 3.5.1
 * Cleanup: reformat all PHP code with WordPress coding style, remove lots of commented code for better clarity. Breathe again!
 * Redesign admin Language Switching Buttons (built-in LSB styles) and 'Copy From' button with new ergonomics.
@@ -127,4 +132,5 @@ The [legacy issues](https://qtranslatexteam.wordpress.com/known-issues/) should 
 * support for Gutenberg (!!)
 * support for translatable slugs (!)
 * support for WooCommerce (revive the add-on!)
+* unit/integration tests
 * legacy of [desirable features](https://qtranslatexteam.wordpress.com/desirable/).


### PR DESCRIPTION
Following issue https://github.com/qtranslate/qtranslate-xt/issues/609 i think i found a reasonable solution to prevent these nasty API REST redirects:
- REST calls should never redirect! Added a check with `qtranxf_is_rest_request_expected` based on `rest_get_url_prefix`.
- REST calls should be fully deterministic! Updated `qtranxf_detect_language` : REST calls should ignore any front/admin cookie and any other weird language detection.
- new init action `qtranxf_rest_api_register_rewrites` for specific rewrite rules to handle the case i described  earlier, when the default language is hidden in the options, but asked in the request. Note to make it work you have to **flush your rewrite rules by saving the permalink structures** from the admin page!

More info in https://github.com/qtranslate/qtranslate-xt/issues/609. I'm quite confident it should work so i'm very tempted to push this to master, also because i want most of people to validate it, but i'll wait a few days  with this PR giving you the possibility to try it first / comment it.

Should also fix related issues (imported from qTranslate-X): https://github.com/qtranslate/qtranslate-xt/issues/575, https://github.com/qtranslate/qtranslate-xt/issues/528, https://github.com/qtranslate/qtranslate-xt/issues/489, https://github.com/qtranslate/qtranslate-xt/issues/427.