### PR TITLE
Xabispacebiker show alternative content prefix

### DIFF
--- a/admin/qtx_configuration.php
+++ b/admin/qtx_configuration.php
@@ -385,6 +385,13 @@ function qtranxf_conf() {
                                                                              value="1"<?php checked( $q_config['show_alternative_content'] ) ?>/> <?php _e( 'Show content in an alternative language when translation is not available for the selected language.', 'qtranslate' ) ?>
                                 </label>
                                 <p class="qtranxs-notes"><?php printf( __( 'When a page or a post with an untranslated content is viewed, a message with a list of other available languages is displayed, in which languages are ordered as defined by option "%s". If this option is on, then the content of the first available language will also be shown, instead of the expected language, for the sake of user convenience.', 'qtranslate' ), __( 'Default Language / Order', 'qtranslate' ) ) ?></p>
+				<br />
+                                <label for="show_alternative_content_prefix"><input type="checkbox"
+                                                                             name="show_alternative_content_prefix"
+                                                                             id="show_alternative_content_prefix"
+                                                                             value="1"<?php checked( $q_config['show_alternative_content_prefix'] ) ?>/> <?php _e( 'Show alternative content language prefix.', 'qtranslate' ) ?>
+                                </label>
+                                <p class="qtranxs-notes"><?php printf( __( 'When alternate content is activacted, show the prefix text "for the sake of user convenience.', 'qtranslate' ), __( 'Default Language / Order', 'qtranslate' ) ) ?></p>
                             </td>
                         </tr>
                         <tr>

--- a/qtranslate_core.php
+++ b/qtranslate_core.php
@@ -1783,7 +1783,7 @@ function qtranxf_use_content( $lang, $content, $available_langs, $show_available
 	if ( ! empty( $q_config['show_alternative_content'] ) && $q_config['show_alternative_content'] ) {
 		// show content in  alternative language
 		if ( sizeof( $available_langs ) > 1 ) {
-			if ( $alt_lang_is_default ) {
+			if ( $alt_lang_is_default && $q_config['show_alternative_content'] ) {
 				// translators: this message is shown to user, when a translation is not available for the active language, but there are multiple other translations available, and post content is shown in the default language of the site.
 				$msg = __( 'For the sake of viewer convenience, the content is shown below in the default language of this site.', 'qtranslate' );
 			} else {
@@ -1792,7 +1792,7 @@ function qtranxf_use_content( $lang, $content, $available_langs, $show_available
 			}
 			// translators: this message is appended to one of the two messages above.
 			$msg .= ' ' . __( 'You may click one of the links to switch the site language to another available language.', 'qtranslate' );
-		} else {
+		} else if ($q_config['show_alternative_content_prefix']) {
 			// translators: this message is shown to user, when a translation is not available for the active language, and there is only one other availabe language.
 			$msg = __( 'For the sake of viewer convenience, the content is shown below in the alternative language.', 'qtranslate' );
 			// translators: this message is appended to the message above.

--- a/qtranslate_options.php
+++ b/qtranslate_options.php
@@ -75,6 +75,7 @@ function qtranxf_set_default_options( &$ops ) {
 		'hide_untranslated'              => false,// hide pages without content
 		'show_displayed_language_prefix' => true,
 		'show_alternative_content'       => false,
+		'show_alternative_content_prefix'=> false,
 		'hide_default_language'          => true,// hide language tag for default language in urls
 		'use_secure_cookie'              => false,
 		'header_css_on'                  => true,


### PR DESCRIPTION
This patch, gives the option to choose whether or not to display the "For the sake of viewer convenience" text when alternative content is enabled.