### PR TITLE
Update qtx_import_export.php

### DIFF
--- a/admin/qtx_import_export.php
+++ b/admin/qtx_import_export.php
@@ -47,7 +47,7 @@ function qtranxf_migrate_options_copy( $nm_to, $nm_from ) {
 			case 'qtranslate_page_configs':
 			case 'qtranslate_admin_config':
 			case 'qtranslate_front_config':
-				continue;
+				continue 2;
 			default:
 				break;
 		}


### PR DESCRIPTION
"continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in E:\var\www\html\wp\wp-content\plugins\qtranslate-xt\admin\qtx_import_export.php on line 50