### PR TITLE
Fix AMP url for themes like Penci Soledad

### DIFF
--- a/qtranslate_core.php
+++ b/qtranslate_core.php
@@ -1127,6 +1127,14 @@ function qtranxf_url_set_language( $urlinfo, $lang, $showLanguage ) {
 			case QTX_URL_PATH: // pre-path
 				//qtranxf_dbg_log_if(!isset($urlinfo['wp-path']),'qtranxf_url_set_language: wp-path not set $urlinfo:',$urlinfo,true);
 				$urlinfo['wp-path'] = '/' . $lang . $urlinfo['wp-path'];
+
+				// fix potential bug with AMP sites which leads to broken links like `/en/amp/en/...
+				// do this by replacing `/en/amp/en/` by `/en/amp/`
+				$ampIssueString = "/${lang}/amp/${lang}/";
+				if(strpos($urlinfo['wp-path'], $ampIssueString) !== false) {
+					$ampFixedString = "/${lang}/amp/";
+					$urlinfo['wp-path'] = str_replace($ampIssueString, $ampFixedString, $urlinfo['wp-path']);
+				}
 				break;
 			case QTX_URL_DOMAIN: // pre-domain
 				$urlinfo['host'] = $lang . '.' . $urlinfo['host'];


### PR DESCRIPTION
Hi,

I had an issue with the Penci Soledad AMP plugin, which caused qtranslate-xt to modify the localised URL twice (once before `/amp/` and once after). This resulted in a 404 for all internal links.

While I could not figure out the real cause (lack of time), this fixes
the localised URL string. It does so by looking
for a string like `/en/amp/en/` and replacing it as `/en/amp/`, so
both AMP and qtranslate-xt are happy and can be used in parallel.

This is tested with Penci Soledad AMP, but not with the official
AMP plugin from Wordpress/Google.

Please review