### PR TITLE
Using strtotime() instead of time() + $seconds

### DIFF
--- a/admin/qtx_activation_hook.php
+++ b/admin/qtx_activation_hook.php
@@ -728,8 +728,8 @@ function qtranxf_activation_hook() {
 	$ts                     = time();
 	$next_thanks            = get_option( 'qtranslate_next_thanks' );
 	$check_qtranslate_forks = $next_thanks === false;
-	if ( $next_thanks !== false && $next_thanks < $ts + 7 * 24 * 60 * 60 ) {
-		$next_thanks = $ts + rand( 10, 20 ) * 24 * 60 * 60;
+	if ( $next_thanks !== false && $next_thanks < strtotime( '+7days', $ts ) ) {
+		$next_thanks = strtotime( '+' . rand( 10, 20 ) . 'days' );
 		update_option( 'qtranslate_next_thanks', $next_thanks );
 	}
 	$messages = qtranxf_update_admin_notice( 'next_thanks', true );

--- a/admin/qtx_admin.php
+++ b/admin/qtx_admin.php
@@ -228,7 +228,7 @@ function qtranxf_admin_init() {
 		$next_thanks = false;
 	}
 	if ( $next_thanks === false ) {
-		$next_thanks = time() + rand( 100, 300 ) * 24 * 60 * 60;
+		$next_thanks = strtotime( '+' . rand( 100, 300 ) . 'days' );
 		update_option( 'qtranslate_next_thanks', $next_thanks );
 	}
 

--- a/admin/qtx_update_gettext_db.php
+++ b/admin/qtx_update_gettext_db.php
@@ -27,7 +27,7 @@ function qtranxf_updateGettextDatabasesEx( $force = false, $only_for_language = 
 		if ( time() < $next_update && ! $force ) {
 			return true;
 		}
-		update_option( 'qtranslate_next_update_mo', time() + 7 * 24 * 60 * 60 );
+		update_option( 'qtranslate_next_update_mo', strtotime('+7days') );
 	}
 
 	require_once ABSPATH . 'wp-admin/includes/translation-install.php';

--- a/qtranslate_core.php
+++ b/qtranslate_core.php
@@ -452,7 +452,7 @@ function qtranxf_setcookie_language( $lang, $cookie_name, $cookie_path, $cookie_
 	//	doing_it_wrong('qtranxf_setcookie_language', 'Headers are already sent, which should not be a case within action "plugins_loaded"', 'any');
 	//	return;
 	//}
-	setcookie( $cookie_name, $lang, time() + 31536000, $cookie_path, $cookie_domain, $secure );//one year
+	setcookie( $cookie_name, $lang, strtotime( '+1year' ), $cookie_path, $cookie_domain, $secure );//one year
 	//two weeks 1209600
 }
 


### PR DESCRIPTION
Use of the strtotime function instead of time.
The strtotime function avoids errors by DST.