### PR TITLE
Shorten message for alt content

### DIFF
--- a/admin/qtx_configuration.php
+++ b/admin/qtx_configuration.php
@@ -364,27 +364,27 @@ function qtranxf_conf() {
                                 <br/>
                                 <label for="hide_untranslated"><input type="checkbox" name="hide_untranslated"
                                                                       id="hide_untranslated"
-                                                                      value="1"<?php checked( $q_config['hide_untranslated'] ) ?>/> <?php _e( 'Hide Content which is not available for the selected language.', 'qtranslate' ) ?>
+                                                                      value="1"<?php checked( $q_config['hide_untranslated'] ) ?>/> <?php _e( 'Hide posts which content is not available for the selected language.', 'qtranslate' ) ?>
                                 </label>
                                 <br/>
                                 <p class="qtranxs-notes"><?php _e( 'When checked, posts will be hidden if the content is not available for the selected language. If unchecked, a message will appear showing all the languages the content is available in.', 'qtranslate' ) ?>
 									<?php _e( 'The message about available languages for the content of a post or a page may also appear if a single post display with an untranslated content if viewed directly.', 'qtranslate' ) ?>
 									<?php printf( __( 'This function will not work correctly if you installed %s on a blog with existing entries. In this case you will need to take a look at option "%s" under "%s" section.', 'qtranslate' ), 'qTranslate', __( 'Convert Database', 'qtranslate' ), __( 'Import', 'qtranslate' ) . '/' . __( 'Export', 'qtranslate' ) ) ?></p>
                                 <br/>
-                                <label for="show_displayed_language_prefix"><input type="checkbox"
-                                                                                   name="show_displayed_language_prefix"
-                                                                                   id="show_displayed_language_prefix"
-                                                                                   value="1"<?php checked( $q_config['show_displayed_language_prefix'] ) ?>/> <?php _e( 'Show displayed language prefix when content is not available for the selected language.', 'qtranslate' ) ?>
-                                </label>
-                                <br/>
-                                <p class="qtranxs-notes"><?php _e( 'This is relevant to all fields other than the main content of posts and pages. Such untranslated fields are always shown in an alternative available language, and will be prefixed with the language name in parentheses, if this option is on.', 'qtranslate' ) ?></p>
-                                <br/>
                                 <label for="show_alternative_content"><input type="checkbox"
                                                                              name="show_alternative_content"
                                                                              id="show_alternative_content"
-                                                                             value="1"<?php checked( $q_config['show_alternative_content'] ) ?>/> <?php _e( 'Show content in an alternative language when translation is not available for the selected language.', 'qtranslate' ) ?>
+                                                                             value="1"<?php checked( $q_config['show_alternative_content'] ) ?>/> <?php _e( 'Show post content in an alternative language when translation is not available for the selected language.', 'qtranslate' ) ?>
                                 </label>
                                 <p class="qtranxs-notes"><?php printf( __( 'When a page or a post with an untranslated content is viewed, a message with a list of other available languages is displayed, in which languages are ordered as defined by option "%s". If this option is on, then the content of the first available language will also be shown, instead of the expected language, for the sake of user convenience.', 'qtranslate' ), __( 'Default Language / Order', 'qtranslate' ) ) ?></p>
+                                <br/>
+                                <label for="show_displayed_language_prefix"><input type="checkbox"
+                                                                                   name="show_displayed_language_prefix"
+                                                                                   id="show_displayed_language_prefix"
+                                                                                   value="1"<?php checked( $q_config['show_displayed_language_prefix'] ) ?>/> <?php _e( 'Show displayed language prefix when field content is not available for the selected language.', 'qtranslate' ) ?>
+                                </label>
+                                <br/>
+                                <p class="qtranxs-notes"><?php _e( 'This is relevant to all fields other than the main content of posts and pages. Such untranslated fields are always shown in an alternative available language, and will be prefixed with the language name in parentheses, if this option is on.', 'qtranslate' ) ?></p>
                             </td>
                         </tr>
                         <tr>

--- a/qtranslate_core.php
+++ b/qtranslate_core.php
@@ -1747,7 +1747,6 @@ function qtranxf_use_content( $lang, $content, $available_langs, $show_available
 	// set alternative language to the first available in the order of enabled languages
 	$alt_lang            = current( $available_langs );
 	$alt_content         = $content[ $alt_lang ];
-	$alt_lang_is_default = $alt_lang == $q_config['default_language'];
 
 	if ( ! $show_available ) {
 		if ( $q_config['show_displayed_language_prefix'] ) {
@@ -1779,37 +1778,17 @@ function qtranxf_use_content( $lang, $content, $available_langs, $show_available
 	}
 	//qtranxf_dbg_log('$language_list=',$language_list);
 
-	$msg = '';
 	if ( ! empty( $q_config['show_alternative_content'] ) && $q_config['show_alternative_content'] ) {
-		// show content in  alternative language
-		if ( sizeof( $available_langs ) > 1 ) {
-			if ( $alt_lang_is_default ) {
-				// translators: this message is shown to user, when a translation is not available for the active language, but there are multiple other translations available, and post content is shown in the default language of the site.
-				$msg = __( 'For the sake of viewer convenience, the content is shown below in the default language of this site.', 'qtranslate' );
-			} else {
-				// translators: this message is shown to user, when a translation is not available neither for the active language nor for default one, but there are multiple other translations available, and post content is shown in the first available language.
-				$msg = __( 'For the sake of viewer convenience, the content is shown below in one of the available alternative languages.', 'qtranslate' );
-			}
-			// translators: this message is appended to one of the two messages above.
-			$msg .= ' ' . __( 'You may click one of the links to switch the site language to another available language.', 'qtranslate' );
-		} else {
-			// translators: this message is shown to user, when a translation is not available for the active language, and there is only one other availabe language.
-			$msg = __( 'For the sake of viewer convenience, the content is shown below in the alternative language.', 'qtranslate' );
-			// translators: this message is appended to the message above.
-			$msg .= ' ' . __( 'You may click the link to switch the active language.', 'qtranslate' );
-		}
-		$altlanguagecontent = ' ' . $msg . '</p>' . $alt_content;
+		$altlanguagecontent = '</p>' . $alt_content;
 	} else {
-		//by default, do not show alternative content
 		$altlanguagecontent = '</p>';
 	}
 
 	$output = '<p class="qtranxs-available-languages-message qtranxs-available-languages-message-' . $lang . '">' . preg_replace( '/%LANG:([^:]*):([^%]*)%/', $language_list, $q_config['not_available'][ $lang ] ) . $altlanguagecontent;
 
-	/*
-	 * Chance to customize $output
-	*/
-
+	// chance to customize $output
+	// TODO refactor this filter, legacy $msg kept for retro-compatibility
+	$msg = 'Deprecated message.';
 	return apply_filters( 'i18n_content_translation_not_available', $output, $lang, $language_list, $alt_lang, $alt_content, $msg, $q_config );
 }
 

--- a/qtranslate_core.php
+++ b/qtranslate_core.php
@@ -1778,17 +1778,12 @@ function qtranxf_use_content( $lang, $content, $available_langs, $show_available
 	}
 	//qtranxf_dbg_log('$language_list=',$language_list);
 
+	$msg = preg_replace( '/%LANG:([^:]*):([^%]*)%/', $language_list, $q_config['not_available'][ $lang ] );
+	$output = '<p class="qtranxs-available-languages-message qtranxs-available-languages-message-' . $lang . '">' . $msg . '</p>';
 	if ( ! empty( $q_config['show_alternative_content'] ) && $q_config['show_alternative_content'] ) {
-		$altlanguagecontent = '</p>' . $alt_content;
-	} else {
-		$altlanguagecontent = '</p>';
+		$output .= $alt_content;
 	}
 
-	$output = '<p class="qtranxs-available-languages-message qtranxs-available-languages-message-' . $lang . '">' . preg_replace( '/%LANG:([^:]*):([^%]*)%/', $language_list, $q_config['not_available'][ $lang ] ) . $altlanguagecontent;
-
-	// chance to customize $output
-	// TODO refactor this filter, legacy $msg kept for retro-compatibility
-	$msg = 'Deprecated message.';
 	return apply_filters( 'i18n_content_translation_not_available', $output, $lang, $language_list, $alt_lang, $alt_content, $msg, $q_config );
 }
 


### PR DESCRIPTION
This PR is in substitution of https://github.com/qtranslate/qtranslate-xt/pull/630. This concerns the option "Show alternative content", meant to display the _post content in alternative languages_ when there's no translation for the current language. But instead of adding a new option to remove a part of the message, this becomes the new behavior.

Currently when the "alt content" option is selected many things are shown:
- notice: "Sorry, this entry is only available in %LANG: ...", containing links to allow language switch.
- long message: "For the sake of convenience, the content is shown below [very long text...]"
- the post content in alternative language (default or next in order)

With this PR the goal is to **remove** entirely the second part ("For the sake of convenience...").
As explained in https://github.com/qtranslate/qtranslate-xt/pull/630 it's cumbersome and it has no added value for the user! The first part should be sufficient, it's self-explanatory. Any user can understand what an hyperlink is and there's no real need explaining to the user why a given language is currently displayed. This is more of a debug information for the administrator, who is supposed to know what he's doing when using this option ;)

By removing this long message we also simplify the code. The only complication comes from the hook `i18n_content_translation_not_available` that can be used for a full customization. Here i keep an empty `$msg` for retro-compatibity (it used the contain the 2d part) but we could take the opportunity to review this filter.