### PR TITLE
Making embedded content translatable

### DIFF
--- a/qtranslate_hooks.php
+++ b/qtranslate_hooks.php
@@ -200,8 +200,4 @@ add_filter( '_wp_post_revision_field_post_title', 'qtranxf_showAllSeparated', 0 
 add_filter( '_wp_post_revision_field_post_content', 'qtranxf_showAllSeparated', 0 );
 add_filter( '_wp_post_revision_field_post_excerpt', 'qtranxf_showAllSeparated', 0 );
 
-add_filter( 'oembed_response_data', function ($data) {
-    global $q_config;
-    $data['title'] = qtranxf_split( $data['title'] )[$q_config['language']];
-    return $data;
-} );
+add_filter( 'oembed_response_data', 'qtranxf_useCurrentLanguageIfNotFoundUseDefaultLanguage' );

--- a/qtranslate_hooks.php
+++ b/qtranslate_hooks.php
@@ -199,3 +199,9 @@ add_filter( 'pre_option_rss_language', 'qtranxf_getLanguage', 0 );
 add_filter( '_wp_post_revision_field_post_title', 'qtranxf_showAllSeparated', 0 );
 add_filter( '_wp_post_revision_field_post_content', 'qtranxf_showAllSeparated', 0 );
 add_filter( '_wp_post_revision_field_post_excerpt', 'qtranxf_showAllSeparated', 0 );
+
+add_filter( 'oembed_response_data', function ($data) {
+    global $q_config;
+    $data['title'] = qtranxf_split( $data['title'] )[$q_config['language']];
+    return $data;
+} );


### PR DESCRIPTION
I noticed that embedded content wasn't translated so I looked how it could be done and my file change is the way how I succeeded into doing just that. I'm not sure where it should be placed so I added it in the `qtranslate_hooks` file.

Example link:
https://example.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fexample.com%2Fpage%2F