### PR TITLE
Refactor plugin dirname and basename

### DIFF
--- a/admin/qtx_activation_hook.php
+++ b/admin/qtx_activation_hook.php
@@ -584,7 +584,7 @@ function qtranxf_find_plugin_config_files( &$fn_bnm, &$fn_qtx, $bnm ) {
  * Search for i18n-config.json files
  * see https://github.com/qtranslate/qtranslate-xt/wiki/Integration-Guide/
  *
- * @param string $plugin plugin WP name as relative dir/file.php
+ * @param string $plugin name as relative dir/file.php
  *
  * @return string|bool
  */
@@ -681,7 +681,7 @@ function qtranxf_activation_hook() {
         // Deactivate ourself
         load_plugin_textdomain( 'qtranslate', false, basename( QTRANSLATE_DIR ) . '/lang' );
         $msg = sprintf( __( 'Plugin %s requires PHP version %s at least. This server instance runs PHP version %s. A PHP version %s or higher is recommended. The plugin has not been activated.', 'qtranslate' ), qtranxf_get_plugin_link(), '5.4', PHP_VERSION, '7.3' );
-        deactivate_plugins( QTRANSLATE_FILE );
+        deactivate_plugins( plugin_basename( QTRANSLATE_FILE ) );
         wp_die( $msg );
     }
 

--- a/admin/qtx_activation_hook.php
+++ b/admin/qtx_activation_hook.php
@@ -382,7 +382,7 @@ function qtranxf_search_config_files_theme( $theme = null, $found = null ) {
     if ( file_exists( $fn ) ) {
         $found[] = $fn;
     } else {
-        $fn = WP_PLUGIN_DIR . '/' . qtranxf_plugin_dirname() . '/i18n-config/themes/' . $theme->stylesheet . '/i18n-config.json';
+        $fn = QTRANSLATE_DIR . '/i18n-config/themes/' . $theme->stylesheet . '/i18n-config.json';
         if ( file_exists( $fn ) ) {
             $found[] = $fn;
         }
@@ -399,11 +399,10 @@ function qtranxf_search_config_files_theme( $theme = null, $found = null ) {
  * @since 3.4
  */
 function qtranxf_normalize_config_files( $found ) {
-    $nc         = strlen( WP_CONTENT_DIR );
-    $plugin_dir = WP_PLUGIN_DIR . '/' . qtranxf_plugin_dirname();
-    $np         = strlen( $plugin_dir );
+    $nc = strlen( WP_CONTENT_DIR );
+    $np = strlen( QTRANSLATE_DIR );
     foreach ( $found as $k => $fn ) {
-        if ( substr( $fn, 0, $np ) === $plugin_dir ) {
+        if ( substr( $fn, 0, $np ) === QTRANSLATE_DIR ) {
             $found[ $k ] = '.' . substr( $fn, $np );
         } else if ( substr( $fn, 0, $nc ) === WP_CONTENT_DIR ) {
             $found[ $k ] = substr( $fn, $nc + 1 );
@@ -441,24 +440,22 @@ function qtranxf_find_plugin_by_folder( $fld, $plugins ) {
  * @since 3.4
  */
 function qtranxf_search_config_files() {
-    $found      = qtranxf_search_config_files_theme();
-    $plugins    = wp_get_active_and_valid_plugins();
-    $plugin_bnm = qtranxf_plugin_dirname();
-    $plugin_dir = WP_PLUGIN_DIR . '/' . $plugin_bnm;
+    $found   = qtranxf_search_config_files_theme();
+    $plugins = wp_get_active_and_valid_plugins();
+    // Caution: plugin files are given here in absolute paths, not relative - wrong WP PHPDoc!
     foreach ( $plugins as $plugin ) {
-        $dir = dirname( $plugin );
-        $bnm = basename( $dir );
-        if ( $bnm === $plugin_bnm ) {
+        if ( $plugin === QTRANSLATE_FILE ) {
             continue;
         }
-        $fn = $dir . '/i18n-config.json';
-        if ( ! file_exists( $fn ) ) {
-            $fn = $plugin_dir . '/i18n-config/plugins/' . $bnm . '/i18n-config.json';
-            if ( ! file_exists( $fn ) ) {
+        $plugin_dir  = dirname( $plugin );
+        $config_file = $plugin_dir . '/i18n-config.json';
+        if ( ! is_readable( $config_file ) ) {
+            $config_file = QTRANSLATE_DIR . '/i18n-config/plugins/' . basename( $plugin_dir ) . '/i18n-config.json';
+            if ( ! is_readable( $config_file ) ) {
                 continue;
             }
         }
-        $found[] = $fn;
+        $found[] = $config_file;
     }
 
     return qtranxf_normalize_config_files( $found );
@@ -587,24 +584,27 @@ function qtranxf_find_plugin_config_files( &$fn_bnm, &$fn_qtx, $bnm ) {
  * Search for i18n-config.json files
  * see https://github.com/qtranslate/qtranslate-xt/wiki/Integration-Guide/
  *
- * @param string $plugin_dir
+ * @param string $plugin plugin WP name as relative dir/file.php
  *
  * @return string|bool
  */
-function qtranxf_find_plugin_config_file( $plugin_dir ) {
+function qtranxf_find_plugin_config_file( $plugin ) {
+    $plugin_rel = dirname( $plugin );
 
-    $config_path = qtranxf_find_plugin_file( $plugin_dir . '/i18n-config.json' );
+    $config_path = qtranxf_find_plugin_file( $plugin_rel . '/i18n-config.json' );
     if ( $config_path ) {
         return $config_path;
     }
 
-    $config_sub_path = qtranxf_plugin_dirname() . '/i18n-config/plugins/' . $plugin_dir . '/i18n-config.json';
+    $qtx_rel = basename( QTRANSLATE_DIR );
+
+    $config_sub_path = $qtx_rel . '/i18n-config/plugins/' . $plugin_rel . '/i18n-config.json';
     $config_path     = qtranxf_find_plugin_file( $config_sub_path );
     if ( $config_path ) {
         return $config_path;
     }
 
-    $config_sub_path = qtranxf_plugin_dirname() . '/i18n-config/themes/' . $plugin_dir . '/i18n-config.json';
+    $config_sub_path = $qtx_rel . '/i18n-config/themes/' . $plugin_rel . '/i18n-config.json';
     $config_path     = qtranxf_find_plugin_file( $config_sub_path );
     if ( $config_path ) {
         return $config_path;
@@ -636,13 +636,10 @@ function qtranxf_adjust_config_files( $file_to_add, $file_to_del ) {
 }
 
 function qtranxf_on_activate_plugin( $plugin, $network_wide = false ) {
-    //qtranxf_dbg_log('qtranxf_on_activate_plugin: $plugin: ',$plugin);
-    $plugin_dir = dirname( $plugin );
-    $qtx_dir    = qtranxf_plugin_dirname();
-    if ( $plugin_dir == $qtx_dir ) {
+    if ( $plugin === plugin_basename( QTRANSLATE_FILE ) ) {
         return;
     }
-    $file_to_add = qtranxf_find_plugin_config_file( $plugin_dir );
+    $file_to_add = qtranxf_find_plugin_config_file( $plugin );
     if ( $file_to_add ) {
         qtranxf_adjust_config_files( $file_to_add, null );
     }
@@ -651,13 +648,10 @@ function qtranxf_on_activate_plugin( $plugin, $network_wide = false ) {
 add_action( 'activate_plugin', 'qtranxf_on_activate_plugin' );
 
 function qtranxf_on_deactivate_plugin( $plugin, $network_deactivating = false ) {
-    //qtranxf_dbg_log('qtranxf_on_deactivate_plugin: $plugin: ',$plugin);
-    $plugin_dir = dirname( $plugin );
-    $qtx_dir    = qtranxf_plugin_dirname();
-    if ( $plugin_dir == $qtx_dir ) {
+    if ( $plugin === plugin_basename( QTRANSLATE_FILE ) ) {
         return;
     }
-    $file_to_del = qtranxf_find_plugin_config_file( $plugin_dir );
+    $file_to_del = qtranxf_find_plugin_config_file( $plugin );
     if ( $file_to_del ) {
         qtranxf_adjust_config_files( null, $file_to_del );
     }
@@ -685,11 +679,9 @@ function qtranxf_activation_hook() {
     //qtranxf_dbg_log('qtranxf_activation_hook: ', __FILE__);
     if ( version_compare( PHP_VERSION, '5.4' ) < 0 ) {
         // Deactivate ourself
-        $plugin_dir = qtranxf_plugin_dirname();
-        $lang_dir   = $plugin_dir . '/lang';
-        load_plugin_textdomain( 'qtranslate', false, $lang_dir );
+        load_plugin_textdomain( 'qtranslate', false, basename( QTRANSLATE_DIR ) . '/lang' );
         $msg = sprintf( __( 'Plugin %s requires PHP version %s at least. This server instance runs PHP version %s. A PHP version %s or higher is recommended. The plugin has not been activated.', 'qtranslate' ), qtranxf_get_plugin_link(), '5.4', PHP_VERSION, '7.3' );
-        deactivate_plugins( $plugin_dir . '/qtranslate.php' );
+        deactivate_plugins( QTRANSLATE_FILE );
         wp_die( $msg );
     }
 

--- a/admin/qtx_activation_hook.php
+++ b/admin/qtx_activation_hook.php
@@ -944,7 +944,7 @@ function qtranxf_admin_notice_dismiss_script() {
 
 /** register activation/deactivation hooks */
 function qtranxf_register_activation_hooks() {
-    $qtx_plugin_basename = qtranxf_plugin_basename();
+    $qtx_plugin_basename = plugin_basename( QTRANSLATE_FILE );
     register_activation_hook( $qtx_plugin_basename, 'qtranxf_activation_hook' );
     register_deactivation_hook( $qtx_plugin_basename, 'qtranxf_deactivation_hook' );
     QTX_Admin_Modules::register_hooks();

--- a/admin/qtx_admin.php
+++ b/admin/qtx_admin.php
@@ -860,7 +860,7 @@ function qtranxf_admin_footer_update( $text ) {
     if ( qtranxf_admin_is_config_page() ) {
         $text        = sprintf( __( 'Plugin Version %s', 'qtranslate' ), QTX_VERSION );
         $current     = get_site_transient( 'update_plugins' );
-        $plugin_file = qtranxf_plugin_basename();
+        $plugin_file = plugin_basename( QTRANSLATE_FILE );
         if ( isset( $current->response[ $plugin_file ] ) ) {
             $data = $current->response[ $plugin_file ];
             if ( is_plugin_active_for_network( $plugin_file ) ) {
@@ -880,7 +880,7 @@ function qtranxf_admin_footer_update( $text ) {
 function qtranxf_admin_load() {
     qtranxf_admin_loadConfig();
 
-    $basename = qtranxf_plugin_basename();
+    $basename = plugin_basename( QTRANSLATE_FILE );
     add_filter( 'plugin_action_links_' . $basename, 'qtranxf_links', 10, 4 );
     // should be executed after all plugins loaded their *-admin.php
     add_action( 'qtranslate_init_language', 'qtranxf_load_admin_page_config', 20 );

--- a/qtranslate.php
+++ b/qtranslate.php
@@ -58,7 +58,7 @@ define( 'QTX_VERSION', '3.7.2' );
 
 if ( ! defined( 'QTRANSLATE_FILE' ) ) {
     define( 'QTRANSLATE_FILE', __FILE__ );
-    define( 'QTRANSLATE_DIR', dirname( __FILE__ ) );
+    define( 'QTRANSLATE_DIR', __DIR__ );
 }
 
 require_once( QTRANSLATE_DIR . '/inc/qtx_class_translator.php' );

--- a/qtranslate_core.php
+++ b/qtranslate_core.php
@@ -562,9 +562,7 @@ function qtranxf_load_option_qtrans_compatibility() {
 }
 
 function qtranxf_load_plugin_textdomain() {
-    $domain   = 'qtranslate';
-    $lang_dir = qtranxf_plugin_dirname() . '/lang';
-    if ( load_plugin_textdomain( $domain, false, $lang_dir ) ) {
+    if ( load_plugin_textdomain( 'qtranslate', false, basename( QTRANSLATE_DIR ) . '/lang' ) ) {
         return true;
     }
 

--- a/qtranslate_utils.php
+++ b/qtranslate_utils.php
@@ -19,12 +19,9 @@ function qtranxf_translate_wp( $string ) {
  * @since 3.3.8.8
  */
 function qtranxf_plugin_basename() {
-    static $basename;
-    if ( ! $basename ) {
-        $basename = plugin_basename( wp_normalize_path( QTRANSLATE_FILE ) );
-    }
+    _deprecated_function( __FUNCTION__, '3.7.3', 'plugin_basename( QTRANSLATE_FILE )' );
 
-    return $basename;
+    return plugin_basename( QTRANSLATE_FILE );
 }
 
 /**

--- a/qtranslate_utils.php
+++ b/qtranslate_utils.php
@@ -31,13 +31,9 @@ function qtranxf_plugin_basename() {
  * @since 3.3.2
  */
 function qtranxf_plugin_dirname() {
-    static $dirname;
-    if ( ! $dirname ) {
-        $basename = qtranxf_plugin_basename();
-        $dirname  = dirname( $basename );
-    }
+    _deprecated_function( __FUNCTION__, '3.7.3', 'dirname( QTRANSLATE_DIR )' );
 
-    return $dirname;
+    return dirname( QTRANSLATE_DIR );
 }
 
 /**


### PR DESCRIPTION
These two utility functions are unnecessary, they are bloating the code and lead to confusions: 
- `qtranxf_plugin_dirname() -> qtranslate`
- `qtranxf_plugin_basename() -> qtranslate/qtranslate.php`

Using directly the basic functions make the code more readable. The legacy functions become deprecated.

- `qtranxf_plugin_dirname() -> dirname( QTRANSLATE_DIR )`
- `qtranxf_plugin_basename() ->  plugin_basename( QTRANSLATE_FILE )`

Code cleanup follows.