### PR TITLE
Fix excerpt not set on post edit in Gutenberg

### DIFF
--- a/admin/qtx_admin_gutenberg.php
+++ b/admin/qtx_admin_gutenberg.php
@@ -183,7 +183,11 @@ class QTX_Admin_Gutenberg {
         if ( isset( $response_data['content'] ) && is_array( $response_data['content'] ) && isset( $response_data['content']['raw'] ) ) {
             $response_data['title']['raw']    = qtranxf_use( $editor_lang, $response_data['title']['raw'], false, true );
             $response_data['content']['raw']  = qtranxf_use( $editor_lang, $response_data['content']['raw'], false, true );
-            $response_data['excerpt']['raw']  = qtranxf_use( $editor_lang, $response_data['excerpt']['raw'], false, true );
+
+            if ( isset( $response_data['excerpt']['raw'] ) ) {
+                $response_data['excerpt']['raw'] = qtranxf_use( $editor_lang, $response_data['excerpt']['raw'], false, true );
+            }
+
             $response_data['qtx_editor_lang'] = $editor_lang;
             $response->set_data( $response_data );
         }


### PR DESCRIPTION
If opening an existing post and the excerpt isn't set then an exception is thrown.
The Exception that I got:

```
ErrorException: Undefined index: excerpt in file plugins/qtranslate-xt/admin/qtx_admin_gutenberg.php on line 188
Stack trace:
  1. ErrorException-&gt;() plugins/qtranslate-xt/admin/qtx_admin_gutenberg.php:188
  2. Themosis\Core\Bootstrap\ExceptionHandler-&gt;handleError() plugins/qtranslate-xt/admin/qtx_admin_gutenberg.php:188
  3. QTX_Admin_Gutenberg-&gt;select_raw_response_language() plugins/qtranslate-xt/admin/qtx_admin_gutenberg.php:70
  4. QTX_Admin_Gutenberg-&gt;rest_prepare() wp-includes/class-wp-hook.php:288
  5. WP_Hook-&gt;apply_filters() wp-includes/plugin.php:206
  6. apply_filters() wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php:1688
  7. WP_REST_Posts_Controller-&gt;prepare_item_for_response() wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php:472
  8. WP_REST_Posts_Controller-&gt;get_item() wp-includes/rest-api/class-wp-rest-server.php:946
  9. WP_REST_Server-&gt;dispatch() wp-includes/rest-api.php:429
 10. rest_do_request() wp-includes/rest-api.php:1539
 11. rest_preload_api_request() [internal]:0
 12. array_reduce() wp-admin/edit-form-blocks.php:77
 13. include() wp-admin/post.php:179
```

Ps. I'm using [Themosis](https://framework.themosis.com). But this shouldn't have an effect on the outcome.