### PR TITLE
hreflang tag to default language

### DIFF
--- a/qtranslate_frontend.php
+++ b/qtranslate_frontend.php
@@ -48,7 +48,7 @@ function qtranxf_wp_head() {
             $hreflang = $lang;
         }
         //if($language != qtranxf_getLanguage())//standard requires them all
-        echo '<link hreflang="' . $hreflang . '" href="' . qtranxf_convertURL( '', $lang, false, true ) . '" rel="alternate" />' . PHP_EOL;
+        echo '<link hreflang="' . $hreflang . '" href="' . qtranxf_convertURL( '', $lang, false, false ) . '" rel="alternate" />' . PHP_EOL;
     }
     //https://support.google.com/webmasters/answer/189077
     echo '<link hreflang="x-default" href="' . qtranxf_convertURL( '', $q_config['default_language'] ) . '" rel="alternate" />' . PHP_EOL;


### PR DESCRIPTION
If flag Hide URL language information for default language is active - hreflang to default language anyway include lang-pach.
Changing qtranxf_convertURL to defalult false - fix this problem