### PR TITLE
FIX: Translate product name in WC order admin page

### DIFF
--- a/modules/woo-commerce/qwc-admin.php
+++ b/modules/woo-commerce/qwc-admin.php
@@ -74,6 +74,7 @@ function qwc_add_admin_page_config( $page_configs ) {
     $fields['inp-variable_description'] = array( 'jquery' => 'textarea[name^=variable_description]' );
     $fields['_purchase_note']           = array();
     $fields['td-attribute_name']        = array( 'jquery' => 'td.attribute_name', 'encode' => 'display' );
+    $fields['a-wc-order-item-name']     = array( 'jquery' => 'a.wc-order-item-name', 'encode' => 'display' );
     $fields['strong-attribute_name']    = array( 'jquery' => 'strong.attribute_name', 'encode' => 'display' );
     $fields['order_number']             = array( 'jquery' => '.order_number', 'encode' => 'display' );
     $fields['display_meta']             = array( 'jquery' => '.display_meta', 'encode' => 'display' );


### PR DESCRIPTION
When viewing WooCommerce orders from the admin side, the name of the product ('item') wouldn't be translated properly.

Here's the issue in the admin (edit order) page:

![Screenshot 2020-04-26 at 16 08 57](https://user-images.githubusercontent.com/150431/80301715-4e072c00-87d8-11ea-86cb-fc4078849b95.jpg)


(P.S. I agree as herrvigg said that the Woocommerce file doing all this in PHP is messy, and should be changed to JSON. That's an issue for another time...)