### PR TITLE
Add CSS for language col in WC products page

### DIFF
--- a/modules/woo-commerce/qwc-admin.css
+++ b/modules/woo-commerce/qwc-admin.css
@@ -1,0 +1,3 @@
+.fixed .column-language {
+        width:10%;
+}

--- a/modules/woo-commerce/qwc-admin.php
+++ b/modules/woo-commerce/qwc-admin.php
@@ -45,6 +45,12 @@ function qwc_add_filters_admin() {
 
 qwc_add_filters_admin();
 
+add_action( 'admin_enqueue_scripts', 'qwc_add_admin_styles' );
+function qwc_add_admin_styles() {
+        wp_register_style( 'qwc_qtranslate_admin', plugins_url( '/assets/qwc-admin.css', __FILE__ ), array(), QTX_VERSION);
+        wp_enqueue_style( 'qwc_qtranslate_admin', plugins_url( '/assets/qwc-admin.css', __FILE__ ), array(), QTX_VERSION);
+}
+
 add_filter( 'qtranslate_load_admin_page_config', 'qwc_add_admin_page_config' );
 function qwc_add_admin_page_config( $page_configs ) {
     // post.php


### PR DESCRIPTION
Fixes #804

I'm not sure if this is the best way - adding custom CSS files to each module - but it seems like the most extensible going forwards. I see that the acf module also does this.