### PR TITLE
Fix paragraph deleting in classic ACF WYSIWYG

### DIFF
--- a/admin/js/common.js
+++ b/admin/js/common.js
@@ -649,7 +649,7 @@ function qtranxj_ce(tagName, props, pNode, isFirst) {
 
         var updateTinyMCE = function (h) {
             text = h.contentField.value;
-            if (h.wpautop && window.switchEditors) {
+            if (1) {
                 text = window.switchEditors.wpautop(text);
             }
             h.mce.setContent(text, {format: 'html'});


### PR DESCRIPTION
Before in classic ACF WYSIWYG paragraphs was deleting.
This make classic ACF field work korrectly with qtranslate-xt installed.