### PR TITLE
Redesign language list with icons

### DIFF
--- a/admin/css/qtranslate_configuration.css
+++ b/admin/css/qtranslate_configuration.css
@@ -27,6 +27,10 @@
     display: table-cell;
 }
 
+.qtranxs-language-list .disabled {
+    opacity: 40%;
+}
+
 #qtranxs-enabled-languages td {
     padding: 0 5px 0 0;
     display: table-cell;

--- a/admin/qtx_admin_settings_language_list.php
+++ b/admin/qtx_admin_settings_language_list.php
@@ -27,7 +27,9 @@ class QTX_Admin_Settings_Language_List extends WP_List_Table {
         return array(
             'code'   => _x( 'Code', 'Two-letter Language Code meant.', 'qtranslate' ),
             'flag'   => __( 'Flag', 'qtranslate' ),
+            'locale' => __( 'Locale', 'qtranslate' ),
             'name'   => __( 'Name', 'qtranslate' ),
+            'status' => __( 'Status', 'qtranslate' ),
             'action' => __( 'Action', 'qtranslate' ),
             'edit'   => __( 'Edit', 'qtranslate' ),
             'stored' => __( 'Stored', 'qtranslate' )
@@ -38,6 +40,7 @@ class QTX_Admin_Settings_Language_List extends WP_List_Table {
         global $q_config;
 
         $flags                 = qtranxf_language_configured( 'flag' );
+        $locales               = qtranxf_language_configured( 'locale' );
         $languages_stored      = get_option( 'qtranslate_language_names', array() );
         $languages_predef      = qtranxf_default_language_name();
         $flag_location_url     = qtranxf_flag_location();
@@ -45,6 +48,7 @@ class QTX_Admin_Settings_Language_List extends WP_List_Table {
         $flag_location_url_def = content_url( qtranxf_flag_location_default() );
         $options_uri           = $this->options_uri;
         $data                  = array();
+
         foreach ( $this->language_names as $lang => $language ) {
             if ( $lang == 'code' ) {
                 continue;
@@ -55,13 +59,51 @@ class QTX_Admin_Settings_Language_List extends WP_List_Table {
             } else {
                 $flag_url = $flag_location_url_def . $flag;
             }
+            $flag_item = '<img src="' . $flag_url . '" alt="' . sprintf( __( '%s Flag', 'qtranslate' ), $language ) . '">';
+
+            if ( isset( $q_config['locale'][ $lang ] ) ) {
+                $locale_item = $q_config['locale'][ $lang ];
+            } else {
+                $locale_item = isset( $locales[ $lang ] ) ? $locales[ $lang ] : '?';
+            }
+
+            $icon_enable  = 'dashicons dashicons-insert';
+            $icon_disable = 'dashicons dashicons-remove';
+            if ( in_array( $lang, $q_config['enabled_languages'] ) ) {
+                if ( $q_config['default_language'] == $lang ) {
+                    $status = '<span class="dashicons dashicons-star-filled" title="' . esc_attr( __( 'Default', 'qtranslate' ) ) . '"></span>';
+                    $action = '<span class="disabled ' . $icon_disable . '"></span>';
+                    $action .= '<span class="disabled ' . $icon_enable . '"></span>';
+                } else {
+                    $status = '<span class="dashicons dashicons-star-empty" title="' . esc_attr( __( 'Enabled', 'qtranslate' ) ) . '"></span>';
+                    $action = '<a class="edit" href="' . $options_uri . '&disable=' . $lang . '#languages" title="' . esc_attr( __( 'Disable', 'qtranslate' ) ) . '"><span class="' . $icon_disable . '"></span></a>';
+                    $action .= '<span class="disabled ' . $icon_enable . '"></span>';
+                }
+            } else {
+                $status = '';
+                $action = '<span class="disabled ' . $icon_disable . '"></span>';
+                $action .= '<a class="edit" href="' . $options_uri . '&enable=' . $lang . '#languages" title="' . esc_attr( __( 'Enable', 'qtranslate' ) ) . '"><span class="' . $icon_enable . '"></span></a>';
+            }
+
+            $edit = '<a class="edit" href="' . $options_uri . '&edit=' . $lang . '" title="' . esc_attr( __( 'Edit', 'qtranslate' ) ) . '"><span class="dashicons dashicons-edit"></span></a>';
+
+            if ( ! isset( $languages_stored[ $lang ] ) ) {
+                $stored = '<span class="dashicons dashicons-saved" title="' . __( 'Pre-Defined', 'qtranslate' ) . '"></span>';
+            } else {
+                $label  = isset( $languages_predef[ $lang ] ) ? __( 'Reset', 'qtranslate' ) : __( 'Delete', 'qtranslate' );
+                $icon   = isset( $languages_predef[ $lang ] ) ? 'dashicons-undo' : 'dashicons-trash';
+                $stored = '<a class="delete" href="' . $options_uri . '&delete=' . $lang . '#languages" title="' . esc_attr( $label ) . '"><span class="dashicons ' . $icon . '"></span></a>';
+            }
+
             $data[] = array(
                 'code'   => $lang,
-                'flag'   => '<img src="' . $flag_url . '" alt="' . sprintf( __( '%s Flag', 'qtranslate' ), $language ) . '">',
+                'flag'   => $flag_item,
                 'name'   => $language,
-                'action' => in_array( $lang, $q_config['enabled_languages'] ) ? ( $q_config['default_language'] == $lang ? __( 'Default', 'qtranslate' ) : '<a class="edit" href="' . $options_uri . '&disable=' . $lang . '#languages">' . __( 'Disable', 'qtranslate' ) . '</a>' ) : '<a class="edit" href="' . $options_uri . '&enable=' . $lang . '#languages">' . __( 'Enable', 'qtranslate' ) . '</a>',
-                'edit'   => '<a class="edit" href="' . $options_uri . '&edit=' . $lang . '">' . __( 'Edit', 'qtranslate' ) . '</a>',
-                'stored' => ! isset( $languages_stored[ $lang ] ) ? __( 'Pre-Defined', 'qtranslate' ) : '<a class="delete" href="' . $options_uri . '&delete=' . $lang . '#languages">' . ( isset( $languages_predef[ $lang ] ) ? __( 'Reset', 'qtranslate' ) : __( 'Delete', 'qtranslate' ) ) . '</a>'
+                'locale' => $locale_item,
+                'status' => $status,
+                'action' => $action,
+                'edit'   => $edit,
+                'stored' => $stored
             );
         }
         $this->items = $data;

--- a/qtranslate.php
+++ b/qtranslate.php
@@ -54,7 +54,7 @@ if ( ! function_exists( 'add_filter' ) ) {
  * Designed as interface for other plugin integration. The documentation is available at
  * https://github.com/qtranslate/qtranslate-xt/wiki/Integration-Guide/
  */
-define( 'QTX_VERSION', '3.9.2' );
+define( 'QTX_VERSION', '3.9.2.dev.2' );
 
 if ( ! defined( 'QTRANSLATE_FILE' ) ) {
     define( 'QTRANSLATE_FILE', __FILE__ );


### PR DESCRIPTION
New design for the language list:
- icons replace the text descriptions, but those are still available when hovering the icons
- add column for the locale (the one for WordPress, this might evolve)
- add column for the status (filled star = default, empty star = enabled, nothing = disabled)

![image](https://user-images.githubusercontent.com/19155375/105103384-d0dfbd80-5ab0-11eb-998b-fa65800769db.png)
