### PR TITLE
Prefix global functions with qtranxf_ in modules

### DIFF
--- a/modules/all-in-one-seo-pack/all-in-one-seo-pack.php
+++ b/modules/all-in-one-seo-pack/all-in-one-seo-pack.php
@@ -6,8 +6,6 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'QAIOSEOP_VERSION', '1.0' );
-
 add_filter( 'qtranslate_compatibility', 'qaioseop_qtrans_compatibility' );
 function qaioseop_qtrans_compatibility( $compatibility ) {
     return true;

--- a/modules/all-in-one-seo-pack/qaioseop-admin.php
+++ b/modules/all-in-one-seo-pack/qaioseop-admin.php
@@ -3,8 +3,8 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-add_filter( 'qtranslate_load_admin_page_config', 'qaioseop_add_admin_page_config' );
-function qaioseop_add_admin_page_config( $page_configs ) {
+add_filter( 'qtranslate_load_admin_page_config', 'qtranxf_aioseop_add_admin_page_config' );
+function qtranxf_aioseop_add_admin_page_config( $page_configs ) {
     // post.php
     $page_config          = array();
     $page_config['pages'] = array( 'post.php' => '', 'term.php' => '' );

--- a/modules/events-made-easy/events-made-easy.php
+++ b/modules/events-made-easy/events-made-easy.php
@@ -12,15 +12,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'QEME_VERSION', '1.1' );
 
-add_filter( 'qtranslate_compatibility', 'qeme_qtrans_compatibility' );
-function qeme_qtrans_compatibility( $compatibility ) {
+add_filter( 'qtranslate_compatibility', 'qtranxf_eme_qtrans_compatibility' );
+function qtranxf_eme_qtrans_compatibility( $compatibility ) {
     return true;
 }
 
-function qeme_init_language( $url_info ) {
+function qtranxf_eme_init_language( $url_info ) {
     if ( ! $url_info['doing_front_end'] ) {
         require_once( dirname( __FILE__ ) . "/qeme-admin.php" );
     }
 }
 
-add_action( 'qtranslate_init_language', 'qeme_init_language' );
+add_action( 'qtranslate_init_language', 'qtranxf_eme_init_language' );

--- a/modules/events-made-easy/events-made-easy.php
+++ b/modules/events-made-easy/events-made-easy.php
@@ -10,8 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'QEME_VERSION', '1.1' );
-
 add_filter( 'qtranslate_compatibility', 'qtranxf_eme_qtrans_compatibility' );
 function qtranxf_eme_qtrans_compatibility( $compatibility ) {
     return true;

--- a/modules/events-made-easy/qeme-admin.php
+++ b/modules/events-made-easy/qeme-admin.php
@@ -9,8 +9,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 //	remove_action('admin_head', 'eme_admin_map_script');//for now, not sure if it is needed, but it was breaking pages
 //}
 
-add_filter( 'qtranslate_load_admin_page_config', 'qeme_add_admin_page_config' );
-function qeme_add_admin_page_config( $page_configs ) {
+add_filter( 'qtranslate_load_admin_page_config', 'qtranxf_eme_add_admin_page_config' );
+function qtranxf_eme_add_admin_page_config( $page_configs ) {
     {//admin.php?page=eme-manager
         $page_config = array();
 

--- a/modules/woo-commerce/qwc-admin.php
+++ b/modules/woo-commerce/qwc-admin.php
@@ -3,7 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-function qwc_add_filters_admin() {
+function qtranxf_wc_add_filters_admin() {
     // priority 20 is used because in case other plugins add some untranslated content on normal priority
     // it will still hopefully then get translated.
     $email_ids = array(
@@ -43,15 +43,15 @@ function qwc_add_filters_admin() {
     }
 }
 
-qwc_add_filters_admin();
+qtranxf_wc_add_filters_admin();
 
-add_action( 'admin_enqueue_scripts', 'qwc_add_admin_styles' );
-function qwc_add_admin_styles() {
-    wp_enqueue_style( 'qwc_qtranslate_admin', plugins_url( '/qwc-admin.css', __FILE__ ), array(), QTX_VERSION );
+add_action( 'admin_enqueue_scripts', 'qtranxf_wc_add_admin_styles' );
+function qtranxf_wc_add_admin_styles() {
+    wp_enqueue_style( 'qtranxf_wc_qtranslate_admin', plugins_url( '/qwc-admin.css', __FILE__ ), array(), QTX_VERSION );
 }
 
-add_filter( 'qtranslate_load_admin_page_config', 'qwc_add_admin_page_config' );
-function qwc_add_admin_page_config( $page_configs ) {
+add_filter( 'qtranslate_load_admin_page_config', 'qtranxf_wc_add_admin_page_config' );
+function qtranxf_wc_add_admin_page_config( $page_configs ) {
     // post.php
     // TODO refactor append config
     if ( ! isset( $page_configs['post'] ) ) {
@@ -241,7 +241,7 @@ function qwc_add_admin_page_config( $page_configs ) {
     return $page_configs;
 }
 
-function qwc_email_get_option( $value_translated, $wce /* WC_Email object*/, $value = null, $key = null, $empty_value = null ) {
+function qtranxf_wc_email_get_option( $value_translated, $wce /* WC_Email object*/, $value = null, $key = null, $empty_value = null ) {
     if ( ! $value ) {
         return $value_translated; // so that older WC versions do not get nasty output
     }
@@ -249,7 +249,7 @@ function qwc_email_get_option( $value_translated, $wce /* WC_Email object*/, $va
     return $value;
 }
 
-add_filter( 'woocommerce_email_get_option', 'qwc_email_get_option', 0, 4 );
+add_filter( 'woocommerce_email_get_option', 'qtranxf_wc_email_get_option', 0, 4 );
 
 add_filter( 'woocommerce_variation_option_name', 'qtranxf_term_name_encoded', 5 );
 
@@ -261,7 +261,7 @@ add_filter( 'woocommerce_variation_option_name', 'qtranxf_term_name_encoded', 5 
  *
  * @return string
  */
-function qwc_admin_url_append_language( $url ) {
+function qtranxf_wc_admin_url_append_language( $url ) {
     if ( strpos( $url, 'action=woocommerce_mark_order_status' ) ) {
         $components = parse_url( $url );
         $params     = array();
@@ -279,7 +279,7 @@ function qwc_admin_url_append_language( $url ) {
     return $url;
 }
 
-add_filter( 'admin_url', 'qwc_admin_url_append_language' );
+add_filter( 'admin_url', 'qtranxf_wc_admin_url_append_language' );
 
 /**
  * Append the language to ajax links on the order edit page, so that mails are sent in the language the customer used
@@ -289,7 +289,7 @@ add_filter( 'admin_url', 'qwc_admin_url_append_language' );
  *
  * @return string
  */
-function qwc_admin_url_append_language_edit_page( $url ) {
+function qtranxf_wc_admin_url_append_language_edit_page( $url ) {
     if ( strpos( $url, 'admin-ajax.php' ) === false || ! isset( $_GET['action'] ) || ! isset( $_GET['post'] ) || $_GET['action'] != 'edit' ) {
         return $url;
     }
@@ -313,7 +313,7 @@ function qwc_admin_url_append_language_edit_page( $url ) {
     return $url;
 }
 
-add_filter( 'admin_url', 'qwc_admin_url_append_language_edit_page' );
+add_filter( 'admin_url', 'qtranxf_wc_admin_url_append_language_edit_page' );
 
 /**
  * Option 'woocommerce_email_from_name' needs to be translated for e-mails, and needs to stay untranslated for settings.
@@ -322,7 +322,7 @@ add_filter( 'admin_url', 'qwc_admin_url_append_language_edit_page' );
  *
  * @return array|mixed|string|void
  */
-function qwc_admin_email_option( $val ) {
+function qtranxf_wc_admin_email_option( $val ) {
     global $q_config;
     global $pagenow;
 
@@ -336,7 +336,7 @@ function qwc_admin_email_option( $val ) {
     }
 }
 
-add_filter( 'option_woocommerce_email_from_name', 'qwc_admin_email_option' );
+add_filter( 'option_woocommerce_email_from_name', 'qtranxf_wc_admin_email_option' );
 
 /**
  * This helps to use order's language on re-sent emails from post.php order edit page.
@@ -346,7 +346,7 @@ add_filter( 'option_woocommerce_email_from_name', 'qwc_admin_email_option' );
  *
  * @return array|mixed|string|void
  */
-function qwc_admin_email_translate( $content, $order = null ) {
+function qtranxf_wc_admin_email_translate( $content, $order = null ) {
     global $q_config;
 
     $lang = null;
@@ -360,7 +360,7 @@ function qwc_admin_email_translate( $content, $order = null ) {
     return qtranxf_use( $lang, $content, false, false );
 }
 
-add_filter( 'woocommerce_email_order_items_table', 'qwc_admin_email_translate', 20, 2 );
+add_filter( 'woocommerce_email_order_items_table', 'qtranxf_wc_admin_email_translate', 20, 2 );
 
 /**
  * Called to process action when button 'Save Order' pressed in /wp-admin/post.php?post=xxx&action=edit
@@ -368,7 +368,7 @@ add_filter( 'woocommerce_email_order_items_table', 'qwc_admin_email_translate', 
  *
  * @param $order
  */
-function qwc_admin_before_resend_order_emails( $order ) {
+function qtranxf_wc_admin_before_resend_order_emails( $order ) {
     if ( ! $order || ! isset( $order->id ) ) {
         return;
     }
@@ -382,19 +382,19 @@ function qwc_admin_before_resend_order_emails( $order ) {
     $q_config['language'] = $lang;
 }
 
-add_action( 'woocommerce_before_resend_order_emails', 'qwc_admin_before_resend_order_emails' );
+add_action( 'woocommerce_before_resend_order_emails', 'qtranxf_wc_admin_before_resend_order_emails' );
 
 /**
- * Undo the effect of qwc_admin_before_resend_order_emails
+ * Undo the effect of qtranxf_wc_admin_before_resend_order_emails
  */
-function qwc_admin_after_resend_order_emails( $order ) {
+function qtranxf_wc_admin_after_resend_order_emails( $order ) {
     global $q_config;
     $q_config['language'] = $q_config['url_info']['language'];
 }
 
-add_action( 'woocommerce_after_resend_order_email', 'qwc_admin_after_resend_order_emails' );
+add_action( 'woocommerce_after_resend_order_email', 'qtranxf_wc_admin_after_resend_order_emails' );
 
-function qwc_admin_filters() {
+function qtranxf_wc_admin_filters() {
     global $pagenow;
     switch ( $pagenow ) {
         case 'admin.php':
@@ -413,4 +413,4 @@ function qwc_admin_filters() {
     }
 }
 
-qwc_admin_filters();
+qtranxf_wc_admin_filters();

--- a/modules/woo-commerce/qwc-front.php
+++ b/modules/woo-commerce/qwc-front.php
@@ -3,10 +3,10 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-function qwc_add_filters_front() {
+function qtranxf_wc_add_filters_front() {
 
     remove_filter( 'get_post_metadata', 'qtranxf_filter_postmeta', 5 );
-    add_filter( 'get_post_metadata', 'qwc_filter_postmeta', 5, 4 );
+    add_filter( 'get_post_metadata', 'qtranxf_wc_filter_postmeta', 5, 4 );
 
     $use_filters = array(
         'woocommerce_attribute'                             => 20,
@@ -39,11 +39,11 @@ function qwc_add_filters_front() {
         add_filter( $name, 'qtranxf_useCurrentLanguageIfNotFoundUseDefaultLanguage', $priority );
     }
 
-    add_action( 'woocommerce_dropdown_variation_attribute_options_args', 'qwc_dropdown_variation_attribute_options_args', 10, 1 );
-    add_filter( 'woocommerce_paypal_args', 'qwc_paypal_args' );
+    add_action( 'woocommerce_dropdown_variation_attribute_options_args', 'qtranxf_wc_dropdown_variation_attribute_options_args', 10, 1 );
+    add_filter( 'woocommerce_paypal_args', 'qtranxf_wc_paypal_args' );
 }
 
-function qwc_filter_postmeta( $original_value, $object_id, $meta_key = '', $single = false ) {
+function qtranxf_wc_filter_postmeta( $original_value, $object_id, $meta_key = '', $single = false ) {
     switch ( $meta_key ) {
         case '_product_attributes':
             return $original_value;
@@ -68,7 +68,7 @@ function qwc_filter_postmeta( $original_value, $object_id, $meta_key = '', $sing
  * @see wc_dropdown_variation_attribute_options (single-product/add-to-cart/variable.php)
  *
  */
-function qwc_dropdown_variation_attribute_options_args( $args ) {
+function qtranxf_wc_dropdown_variation_attribute_options_args( $args ) {
     if ( isset( $args['options'] ) ) {
         $args['options'] = qtranxf_useCurrentLanguageIfNotFoundUseDefaultLanguage( $args['options'] );
     }
@@ -82,13 +82,13 @@ function qwc_dropdown_variation_attribute_options_args( $args ) {
  * do_action( 'woocommerce_checkout_update_order_meta', $order_id, $this->posted );
  * in /woocommerce/includes/class-wc-checkout.php
  */
-add_action( 'woocommerce_checkout_update_order_meta', 'save_post_qwc_store_language', 100 );
-function save_post_qwc_store_language( $order_id ) {
+add_action( 'woocommerce_checkout_update_order_meta', 'qtranxf_wc_save_post_meta', 100 );
+function qtranxf_wc_save_post_meta( $order_id ) {
     global $q_config;
     add_post_meta( $order_id, '_user_language', $q_config['language'], true );
 }
 
-function qwc_paypal_args( $args ) {
+function qtranxf_wc_paypal_args( $args ) {
     $args['lc'] = get_locale();
 
     return $args;
@@ -99,7 +99,7 @@ function qwc_paypal_args( $args ) {
  */
 if ( wp_doing_cron() ) {
 
-    function qwc_deliver_webhook_async( $webhook_id, $arg ) {
+    function qtranxf_wc_deliver_webhook_async( $webhook_id, $arg ) {
         $page_configs = qtranxf_get_front_page_config();
         if ( ! empty( $page_configs['']['filters'] ) ) {
             qtranxf_remove_filters( $page_configs['']['filters'] );
@@ -113,10 +113,10 @@ if ( wp_doing_cron() ) {
         remove_filter( 'get_terms', 'qtranxf_useTermLib', 0 );
     }
 
-    add_action( 'woocommerce_deliver_webhook_async', 'qwc_deliver_webhook_async', 5, 2 );
+    add_action( 'woocommerce_deliver_webhook_async', 'qtranxf_wc_deliver_webhook_async', 5, 2 );
 
 } else {
-    qwc_add_filters_front();
+    qtranxf_wc_add_filters_front();
 }
 
 /**
@@ -126,7 +126,7 @@ if ( wp_doing_cron() ) {
  *
  * @return string cart hash with language information
  */
-function qwc_get_cart_hash( $cart ) {
+function qtranxf_wc_get_cart_hash( $cart ) {
     $lang = qtranxf_getLanguage();
 
     return md5( json_encode( $cart ) . $lang );
@@ -138,8 +138,8 @@ function qwc_get_cart_hash( $cart ) {
  *
  * @param array $cart wc variable holding contents of the cart without language information.
  */
-function qwc_set_cookies_cart_hash( $cart ) {
-    $hash = qwc_get_cart_hash( $cart );
+function qtranxf_wc_set_cookies_cart_hash( $cart ) {
+    $hash = qtranxf_wc_get_cart_hash( $cart );
     wc_setcookie( 'woocommerce_cart_hash', $hash );
 }
 
@@ -149,15 +149,15 @@ function qwc_set_cookies_cart_hash( $cart ) {
  *
  * @param WC_Cart $wc_cart wc object without language information.
  */
-function qwc_cart_loaded_from_session( $wc_cart ) {
+function qtranxf_wc_cart_loaded_from_session( $wc_cart ) {
     if ( headers_sent() ) {
         return;
     }
     $cart = $wc_cart->get_cart_for_session();
-    qwc_set_cookies_cart_hash( $cart );
+    qtranxf_wc_set_cookies_cart_hash( $cart );
 }
 
-add_action( 'woocommerce_cart_loaded_from_session', 'qwc_cart_loaded_from_session', 5 );
+add_action( 'woocommerce_cart_loaded_from_session', 'qtranxf_wc_cart_loaded_from_session', 5 );
 
 /**
  * Dealing with mini-cart cache in internal browser storage.
@@ -165,16 +165,16 @@ add_action( 'woocommerce_cart_loaded_from_session', 'qwc_cart_loaded_from_sessio
  *
  * @param bool $set is true if cookies need to be set, otherwse they are unset in calling function.
  */
-function qwc_set_cart_cookies( $set ) {
+function qtranxf_wc_set_cart_cookies( $set ) {
     if ( $set ) {
         $wc      = WC();
         $wc_cart = $wc->cart;
         $cart    = $wc_cart->get_cart_for_session();
-        qwc_set_cookies_cart_hash( $cart );
+        qtranxf_wc_set_cookies_cart_hash( $cart );
     }
 }
 
-add_action( 'woocommerce_set_cart_cookies', 'qwc_set_cart_cookies' );
+add_action( 'woocommerce_set_cart_cookies', 'qtranxf_wc_set_cart_cookies' );
 
 /**
  * Dealing with mini-cart cache in internal browser storage.
@@ -185,8 +185,8 @@ add_action( 'woocommerce_set_cart_cookies', 'qwc_set_cart_cookies' );
  *
  * @return string cart hash with language information
  */
-function qwc_cart_hash( $hash, $cart ) {
-    $new_hash = qwc_get_cart_hash( $cart );
+function qtranxf_wc_cart_hash( $hash, $cart ) {
+    $new_hash = qtranxf_wc_get_cart_hash( $cart );
     if ( ! headers_sent() ) {
         wc_setcookie( 'woocommerce_cart_hash', $new_hash );
     }
@@ -194,4 +194,4 @@ function qwc_cart_hash( $hash, $cart ) {
     return $new_hash;
 }
 
-add_filter( 'woocommerce_cart_hash', 'qwc_cart_hash', 5, 2 );
+add_filter( 'woocommerce_cart_hash', 'qtranxf_wc_cart_hash', 5, 2 );

--- a/modules/woo-commerce/woo-commerce.php
+++ b/modules/woo-commerce/woo-commerce.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-function qwc_init_language( $url_info ) {
+function qtranxf_wc_init_language( $url_info ) {
     if ( $url_info['doing_front_end'] ) {
         require_once( dirname( __FILE__ ) . "/qwc-front.php" );
     } else {
@@ -14,7 +14,7 @@ function qwc_init_language( $url_info ) {
     }
 }
 
-add_action( 'qtranslate_init_language', 'qwc_init_language' );
+add_action( 'qtranslate_init_language', 'qtranxf_wc_init_language' );
 
 /**
  * Dealing with mini-cart cache in internal browser storage.
@@ -27,7 +27,7 @@ add_action( 'qtranslate_init_language', 'qwc_init_language' );
  *
  * @return array possibly modified $url_info.
  */
-function qwc_detect_language( $url_info ) {
+function qtranxf_wc_detect_language( $url_info ) {
     if ( isset( $url_info['cookie_lang_front'] ) && $url_info['cookie_lang_front'] != $url_info['language'] ) {
         // language is about to switch
         if ( ! empty( $_GET['wc-ajax'] ) && ! empty( $url_info['doing_front_end'] ) ) {
@@ -41,4 +41,4 @@ function qwc_detect_language( $url_info ) {
     return $url_info;
 }
 
-add_filter( 'qtranslate_detect_language', 'qwc_detect_language', 5 );
+add_filter( 'qtranslate_detect_language', 'qtranxf_wc_detect_language', 5 );


### PR DESCRIPTION
For consistency with the convention in qtranslate, all global functions should start with `qtranxf_`. This is also to avoid any name conflict, thought the risk was already very low with the previous names.

Legacy version definitions are also removed.