### PR TITLE
Fixed issue with qTranslate not loading after clicking on the "Edit" button in the frontend

### DIFF
--- a/qtranslate_core.php
+++ b/qtranslate_core.php
@@ -165,11 +165,12 @@ function qtranxf_detect_language( &$url_info ) {
     // parse language and front info from HTTP_REFERER
     if ( isset( $_SERVER['HTTP_REFERER'] ) && $parse_referrer ) {
         $http_referer             = $_SERVER['HTTP_REFERER'];
+        $http_request_uri         = $_SERVER['REQUEST_URI'];
         $url_info['http_referer'] = $http_referer;
 
         // if needed, detect front- vs back-end
         $parse_referrer_language = true;
-        if ( strpos( $http_referer, '/wp-admin' ) !== false ) {
+        if ( strpos( $http_request_uri, '/wp-admin' ) !== false || strpos( $http_referer, '/wp-admin' ) !== false ) {
             $url_info['referer_admin'] = true;
             if ( ! isset( $url_info['doing_front_end'] ) ) {
                 $url_info['doing_front_end'] = false;


### PR DESCRIPTION
We encountered an issue where qTranslate would not load when a user clicks on the "Edit" button in the frontend. This is caused by the check on the referer to see if the previous URL contains "wp-admin". This is obviously not the case when you come from the frontend directly to the edit page in the backend. I modified this check, so that it also checks if the currently called page contains "wp-admin".