### PR TITLE
Remove ajax qtranslate-fields collect as string

### DIFF
--- a/admin/qtx_admin.php
+++ b/admin/qtx_admin.php
@@ -103,35 +103,6 @@ function qtranxf_collect_translations_posted() {
         }
         qtranxf_clean_request( 'qtranslate-fields' );
     }
-
-    if ( wp_doing_ajax() ) {
-        // parse variables collected as a query string in an option
-        foreach ( $_REQUEST as $name => $value ) {
-            if ( ! is_string( $value ) ) {
-                continue;
-            }
-            if ( strpos( $value, 'qtranslate-fields' ) === false ) {
-                continue;
-            }
-            parse_str( $value, $request );
-            if ( empty( $request['qtranslate-fields'] ) ) {
-                continue;
-            }
-            if ( ! $edit_lang ) {
-                $edit_lang = qtranxf_get_edit_language();
-            }
-            qtranxf_collect_translations( $request['qtranslate-fields'], $request, $edit_lang );
-            unset( $request['qtranslate-fields'] );
-            $url_encoded       = http_build_query( $request );
-            $_REQUEST[ $name ] = $url_encoded;
-            if ( isset( $_POST[ $name ] ) ) {
-                $_POST[ $name ] = $url_encoded;
-            }
-            if ( isset( $_GET[ $name ] ) ) {
-                $_GET [ $name ] = $url_encoded;
-            }
-        }
-    }
 }
 
 function qtranxf_decode_translations_posted() {


### PR DESCRIPTION
Collecting `qtranslate-fields` as `string` on AJAX calls seems to be very specific and I really don't understand the use case.
This was introduced in 3.6.8 as:
> Enhancement: in function qtranxf_collect_translations_posted, parse variables collected as a query string in an option.

The regular collections should take care of all the cases, including AJAX requests.
Why would this query ever be passed as string?

Let's remove this to make the code simpler and we can restore it if really needed. This PR is just to keep track of this removal.