### PR TITLE
Fix localization of ACF field labels

### DIFF
--- a/modules/acf/src/acf_5/fields/file.php
+++ b/modules/acf/src/acf_5/fields/file.php
@@ -28,7 +28,7 @@ class acf_qtranslate_acf_5_file extends acf_field_file {
      */
     function initialize() {
         $this->name     = 'qtranslate_file';
-        $this->label    = sprintf( __( "File (%s)", 'qtranslate' ), "qTranslate-XT" );
+        $this->label    = __( "File", 'acf' ) . " (qTranslate-XT)";
         $this->category = "qTranslate-XT";
         $this->defaults = array(
             'return_format' => 'array',

--- a/modules/acf/src/acf_5/fields/file.php
+++ b/modules/acf/src/acf_5/fields/file.php
@@ -28,8 +28,8 @@ class acf_qtranslate_acf_5_file extends acf_field_file {
      */
     function initialize() {
         $this->name     = 'qtranslate_file';
-        $this->label    = __( "File (qTranslate)", 'acf' );
-        $this->category = __( "qTranslate", 'acf' );
+        $this->label    = sprintf( __( "File (%s)", 'qtranslate' ), "qTranslate-XT" );
+        $this->category = "qTranslate-XT";
         $this->defaults = array(
             'return_format' => 'array',
             'library'       => 'all',
@@ -38,10 +38,10 @@ class acf_qtranslate_acf_5_file extends acf_field_file {
             'mime_types'    => ''
         );
         $this->l10n     = array(
-            'select'     => __( "Select File", 'acf' ),
-            'edit'       => __( "Edit File", 'acf' ),
-            'update'     => __( "Update File", 'acf' ),
-            'uploadedTo' => __( "Uploaded to this post", 'acf' ),
+            'select'     => __( "Select File", 'qtranslate' ),
+            'edit'       => __( "Edit File", 'qtranslate' ),
+            'update'     => __( "Update File", 'qtranslate' ),
+            'uploadedTo' => __( "Uploaded to this post", 'qtranslate' ),
         );
 
         add_filter( 'get_media_item_args', array( $this, 'get_media_item_args' ) );
@@ -137,12 +137,12 @@ class acf_qtranslate_acf_5_file extends acf_field_file {
                             <strong data-name="title"><?php echo $atts['title']; ?></strong>
                         </p>
                         <p>
-                            <strong><?php _e( 'File name', 'acf' ); ?>:</strong>
+                            <strong><?php _e( 'File name', 'qtranslate' ); ?>:</strong>
                             <a data-name="filename" href="<?php echo $atts['url']; ?>"
                                target="_blank"><?php echo $atts['filename']; ?></a>
                         </p>
                         <p>
-                            <strong><?php _e( 'File size', 'acf' ); ?>:</strong>
+                            <strong><?php _e( 'File size', 'qtranslate' ); ?>:</strong>
                             <span data-name="filesize"><?php echo $atts['filesize']; ?></span>
                         </p>
 
@@ -165,9 +165,9 @@ class acf_qtranslate_acf_5_file extends acf_field_file {
 
                     <?php else: ?>
 
-                        <p style="margin:0;"><?php _e( 'No file selected', 'acf' ); ?> <a data-name="add"
-                                                                                          class="acf-button button"
-                                                                                          href="#"><?php _e( 'Add File', 'acf' ); ?></a>
+                        <p style="margin:0;"><?php _e( 'No file selected', 'qtranslate' ); ?> <a data-name="add"
+                                                                                                 class="acf-button button"
+                                                                                                 href="#"><?php _e( 'Add File', 'qtranslate' ); ?></a>
                         </p>
 
                     <?php endif; ?>

--- a/modules/acf/src/acf_5/fields/file.php
+++ b/modules/acf/src/acf_5/fields/file.php
@@ -38,10 +38,10 @@ class acf_qtranslate_acf_5_file extends acf_field_file {
             'mime_types'    => ''
         );
         $this->l10n     = array(
-            'select'     => __( "Select File", 'qtranslate' ),
-            'edit'       => __( "Edit File", 'qtranslate' ),
-            'update'     => __( "Update File", 'qtranslate' ),
-            'uploadedTo' => __( "Uploaded to this post", 'qtranslate' ),
+            'select'     => __( "Select File", 'acf' ),
+            'edit'       => __( "Edit File", 'acf' ),
+            'update'     => __( "Update File", 'acf' ),
+            'uploadedTo' => __( "Uploaded to this post", 'acf' ),
         );
 
         add_filter( 'get_media_item_args', array( $this, 'get_media_item_args' ) );
@@ -137,12 +137,12 @@ class acf_qtranslate_acf_5_file extends acf_field_file {
                             <strong data-name="title"><?php echo $atts['title']; ?></strong>
                         </p>
                         <p>
-                            <strong><?php _e( 'File name', 'qtranslate' ); ?>:</strong>
+                            <strong><?php _e( 'File name', 'acf' ); ?>:</strong>
                             <a data-name="filename" href="<?php echo $atts['url']; ?>"
                                target="_blank"><?php echo $atts['filename']; ?></a>
                         </p>
                         <p>
-                            <strong><?php _e( 'File size', 'qtranslate' ); ?>:</strong>
+                            <strong><?php _e( 'File size', 'acf' ); ?>:</strong>
                             <span data-name="filesize"><?php echo $atts['filesize']; ?></span>
                         </p>
 
@@ -165,9 +165,9 @@ class acf_qtranslate_acf_5_file extends acf_field_file {
 
                     <?php else: ?>
 
-                        <p style="margin:0;"><?php _e( 'No file selected', 'qtranslate' ); ?> <a data-name="add"
-                                                                                                 class="acf-button button"
-                                                                                                 href="#"><?php _e( 'Add File', 'qtranslate' ); ?></a>
+                        <p style="margin:0;"><?php _e( 'No file selected', 'acf' ); ?> <a data-name="add"
+                                                                                          class="acf-button button"
+                                                                                          href="#"><?php _e( 'Add File', 'acf' ); ?></a>
                         </p>
 
                     <?php endif; ?>

--- a/modules/acf/src/acf_5/fields/image.php
+++ b/modules/acf/src/acf_5/fields/image.php
@@ -28,7 +28,7 @@ class acf_qtranslate_acf_5_image extends acf_field_image {
      */
     function initialize() {
         $this->name     = 'qtranslate_image';
-        $this->label    = sprintf( __( "Image (%s)", 'qtranslate' ), "qTranslate-XT" );
+        $this->label    = __( "Image", 'acf' ) . " (qTranslate-XT)";
         $this->category = "qTranslate-XT";
         $this->defaults = array(
             'return_format' => 'array',

--- a/modules/acf/src/acf_5/fields/image.php
+++ b/modules/acf/src/acf_5/fields/image.php
@@ -43,11 +43,11 @@ class acf_qtranslate_acf_5_image extends acf_field_image {
             'mime_types'    => ''
         );
         $this->l10n     = array(
-            'select'     => __( "Select Image", 'qtranslate' ),
-            'edit'       => __( "Edit Image", 'qtranslate' ),
-            'update'     => __( "Update Image", 'qtranslate' ),
-            'uploadedTo' => __( "Uploaded to this post", 'qtranslate' ),
-            'all'        => __( "All images", 'qtranslate' ),
+            'select'     => __( "Select Image", 'acf' ),
+            'edit'       => __( "Edit Image", 'acf' ),
+            'update'     => __( "Update Image", 'acf' ),
+            'uploadedTo' => __( "Uploaded to this post", 'acf' ),
+            'all'        => __( "All images", 'acf' ),
         );
 
         add_filter( 'get_media_item_args', array( $this, 'get_media_item_args' ) );
@@ -133,10 +133,10 @@ class acf_qtranslate_acf_5_image extends acf_field_image {
                         <?php
                         if ( $uploader != 'basic' ):
                             ?><a class="acf-icon -pencil dark" data-name="edit" href="#"
-                                 title="<?php _e( 'Edit', 'qtranslate' ); ?>"></a><?php
+                                 title="<?php _e( 'Edit', 'acf' ); ?>"></a><?php
                         endif;
                         ?><a class="acf-icon -cancel dark" data-name="remove" href="#"
-                             title="<?php _e( 'Remove', 'qtranslate' ); ?>"></a>
+                             title="<?php _e( 'Remove', 'acf' ); ?>"></a>
                     </div>
                 </div>
                 <div class="hide-if-value">
@@ -152,9 +152,8 @@ class acf_qtranslate_acf_5_image extends acf_field_image {
 
                     <?php else: ?>
 
-                        <p><?php _e( 'No image selected', 'qtranslate' ); ?> <a data-name="add"
-                                                                                class="acf-button button"
-                                                                                href="#"><?php _e( 'Add Image', 'qtranslate' ); ?></a>
+                        <p><?php _e( 'No image selected', 'acf' ); ?> <a data-name="add" class="acf-button button"
+                                                                         href="#"><?php _e( 'Add Image', 'acf' ); ?></a>
                         </p>
 
                     <?php endif; ?>

--- a/modules/acf/src/acf_5/fields/image.php
+++ b/modules/acf/src/acf_5/fields/image.php
@@ -28,8 +28,8 @@ class acf_qtranslate_acf_5_image extends acf_field_image {
      */
     function initialize() {
         $this->name     = 'qtranslate_image';
-        $this->label    = __( "Image (qTranslate)", 'acf' );
-        $this->category = __( "qTranslate", 'acf' );
+        $this->label    = sprintf( __( "Image (%s)", 'qtranslate' ), "qTranslate-XT" );
+        $this->category = "qTranslate-XT";
         $this->defaults = array(
             'return_format' => 'array',
             'preview_size'  => 'thumbnail',
@@ -43,11 +43,11 @@ class acf_qtranslate_acf_5_image extends acf_field_image {
             'mime_types'    => ''
         );
         $this->l10n     = array(
-            'select'     => __( "Select Image", 'acf' ),
-            'edit'       => __( "Edit Image", 'acf' ),
-            'update'     => __( "Update Image", 'acf' ),
-            'uploadedTo' => __( "Uploaded to this post", 'acf' ),
-            'all'        => __( "All images", 'acf' ),
+            'select'     => __( "Select Image", 'qtranslate' ),
+            'edit'       => __( "Edit Image", 'qtranslate' ),
+            'update'     => __( "Update Image", 'qtranslate' ),
+            'uploadedTo' => __( "Uploaded to this post", 'qtranslate' ),
+            'all'        => __( "All images", 'qtranslate' ),
         );
 
         add_filter( 'get_media_item_args', array( $this, 'get_media_item_args' ) );
@@ -133,10 +133,10 @@ class acf_qtranslate_acf_5_image extends acf_field_image {
                         <?php
                         if ( $uploader != 'basic' ):
                             ?><a class="acf-icon -pencil dark" data-name="edit" href="#"
-                                 title="<?php _e( 'Edit', 'acf' ); ?>"></a><?php
+                                 title="<?php _e( 'Edit', 'qtranslate' ); ?>"></a><?php
                         endif;
                         ?><a class="acf-icon -cancel dark" data-name="remove" href="#"
-                             title="<?php _e( 'Remove', 'acf' ); ?>"></a>
+                             title="<?php _e( 'Remove', 'qtranslate' ); ?>"></a>
                     </div>
                 </div>
                 <div class="hide-if-value">
@@ -152,8 +152,9 @@ class acf_qtranslate_acf_5_image extends acf_field_image {
 
                     <?php else: ?>
 
-                        <p><?php _e( 'No image selected', 'acf' ); ?> <a data-name="add" class="acf-button button"
-                                                                         href="#"><?php _e( 'Add Image', 'acf' ); ?></a>
+                        <p><?php _e( 'No image selected', 'qtranslate' ); ?> <a data-name="add"
+                                                                                class="acf-button button"
+                                                                                href="#"><?php _e( 'Add Image', 'qtranslate' ); ?></a>
                         </p>
 
                     <?php endif; ?>

--- a/modules/acf/src/acf_5/fields/post_object.php
+++ b/modules/acf/src/acf_5/fields/post_object.php
@@ -28,7 +28,7 @@ class acf_qtranslate_acf_5_post_object extends acf_field_post_object {
      */
     function initialize() {
         $this->name     = 'qtranslate_post_object';
-        $this->label    = sprintf( __( "Post Object (%s)", 'qtranslate' ), "qTranslate-XT" );
+        $this->label    = __( "Post Object", 'acf' ) . " (qTranslate-XT)";
         $this->category = "qTranslate-XT";
         $this->defaults = array(
             'post_type'     => array(),

--- a/modules/acf/src/acf_5/fields/post_object.php
+++ b/modules/acf/src/acf_5/fields/post_object.php
@@ -28,8 +28,8 @@ class acf_qtranslate_acf_5_post_object extends acf_field_post_object {
      */
     function initialize() {
         $this->name     = 'qtranslate_post_object';
-        $this->label    = __( "Post Object (qTranslate)", 'acf' );
-        $this->category = 'qTranslate';
+        $this->label    = sprintf( __( "Post Object (%s)", 'qtranslate' ), "qTranslate-XT" );
+        $this->category = "qTranslate-XT";
         $this->defaults = array(
             'post_type'     => array(),
             'taxonomy'      => array(),

--- a/modules/acf/src/acf_5/fields/text.php
+++ b/modules/acf/src/acf_5/fields/text.php
@@ -97,24 +97,24 @@ class acf_qtranslate_acf_5_text extends acf_field_text {
     function render_field_settings( $field ) {
         // default_value
         acf_render_field_setting( $field, array(
-            'label'        => __( 'Default Value', 'qtranslate' ),
-            'instructions' => __( 'Appears when creating a new post', 'qtranslate' ),
+            'label'        => __( 'Default Value', 'acf' ),
+            'instructions' => __( 'Appears when creating a new post', 'acf' ),
             'type'         => 'text',
             'name'         => 'default_value',
         ) );
 
         // placeholder
         acf_render_field_setting( $field, array(
-            'label'        => __( 'Placeholder Text', 'qtranslate' ),
-            'instructions' => __( 'Appears within the input', 'qtranslate' ),
+            'label'        => __( 'Placeholder Text', 'acf' ),
+            'instructions' => __( 'Appears within the input', 'acf' ),
             'type'         => 'text',
             'name'         => 'placeholder',
         ) );
 
         // maxlength
         acf_render_field_setting( $field, array(
-            'label'        => __( 'Character Limit', 'qtranslate' ),
-            'instructions' => __( 'Leave blank for no limit', 'qtranslate' ),
+            'label'        => __( 'Character Limit', 'acf' ),
+            'instructions' => __( 'Leave blank for no limit', 'acf' ),
             'type'         => 'number',
             'name'         => 'maxlength',
         ) );

--- a/modules/acf/src/acf_5/fields/text.php
+++ b/modules/acf/src/acf_5/fields/text.php
@@ -28,8 +28,8 @@ class acf_qtranslate_acf_5_text extends acf_field_text {
      */
     function initialize() {
         $this->name     = 'qtranslate_text';
-        $this->label    = __( "Text (qTranslate)", 'acf' );
-        $this->category = __( "qTranslate", 'acf' );
+        $this->label    = sprintf( __( "Text (%s)", 'qtranslate' ), "qTranslate-XT" );
+        $this->category = "qTranslate-XT";
         $this->defaults = array(
             'default_value' => '',
             'maxlength'     => '',
@@ -97,24 +97,24 @@ class acf_qtranslate_acf_5_text extends acf_field_text {
     function render_field_settings( $field ) {
         // default_value
         acf_render_field_setting( $field, array(
-            'label'        => __( 'Default Value', 'acf' ),
-            'instructions' => __( 'Appears when creating a new post', 'acf' ),
+            'label'        => __( 'Default Value', 'qtranslate' ),
+            'instructions' => __( 'Appears when creating a new post', 'qtranslate' ),
             'type'         => 'text',
             'name'         => 'default_value',
         ) );
 
         // placeholder
         acf_render_field_setting( $field, array(
-            'label'        => __( 'Placeholder Text', 'acf' ),
-            'instructions' => __( 'Appears within the input', 'acf' ),
+            'label'        => __( 'Placeholder Text', 'qtranslate' ),
+            'instructions' => __( 'Appears within the input', 'qtranslate' ),
             'type'         => 'text',
             'name'         => 'placeholder',
         ) );
 
         // maxlength
         acf_render_field_setting( $field, array(
-            'label'        => __( 'Character Limit', 'acf' ),
-            'instructions' => __( 'Leave blank for no limit', 'acf' ),
+            'label'        => __( 'Character Limit', 'qtranslate' ),
+            'instructions' => __( 'Leave blank for no limit', 'qtranslate' ),
             'type'         => 'number',
             'name'         => 'maxlength',
         ) );

--- a/modules/acf/src/acf_5/fields/text.php
+++ b/modules/acf/src/acf_5/fields/text.php
@@ -28,7 +28,7 @@ class acf_qtranslate_acf_5_text extends acf_field_text {
      */
     function initialize() {
         $this->name     = 'qtranslate_text';
-        $this->label    = sprintf( __( "Text (%s)", 'qtranslate' ), "qTranslate-XT" );
+        $this->label    = __( "Text", 'acf' ) . " (qTranslate-XT)";
         $this->category = "qTranslate-XT";
         $this->defaults = array(
             'default_value' => '',

--- a/modules/acf/src/acf_5/fields/textarea.php
+++ b/modules/acf/src/acf_5/fields/textarea.php
@@ -28,8 +28,8 @@ class acf_qtranslate_acf_5_textarea extends acf_field_textarea {
      */
     function initialize() {
         $this->name     = 'qtranslate_textarea';
-        $this->label    = __( "Text Area (qTranslate)", 'acf' );
-        $this->category = __( "qTranslate", 'acf' );
+        $this->label    = sprintf( __( "Textarea (%s)", 'qtranslate' ), "qTranslate-XT" );
+        $this->category = "qTranslate-XT";
         $this->defaults = array(
             'default_value' => '',
             'new_lines'     => '',

--- a/modules/acf/src/acf_5/fields/textarea.php
+++ b/modules/acf/src/acf_5/fields/textarea.php
@@ -28,7 +28,7 @@ class acf_qtranslate_acf_5_textarea extends acf_field_textarea {
      */
     function initialize() {
         $this->name     = 'qtranslate_textarea';
-        $this->label    = sprintf( __( "Textarea (%s)", 'qtranslate' ), "qTranslate-XT" );
+        $this->label    = __( "Textarea", 'acf' ) . " (qTranslate-XT)";
         $this->category = "qTranslate-XT";
         $this->defaults = array(
             'default_value' => '',

--- a/modules/acf/src/acf_5/fields/url.php
+++ b/modules/acf/src/acf_5/fields/url.php
@@ -28,8 +28,8 @@ class acf_qtranslate_acf_5_url extends acf_field_url {
      */
     function initialize() {
         $this->name     = 'qtranslate_url';
-        $this->label    = __( "Url (qTranslate)", 'acf' );
-        $this->category = __( "qTranslate", 'acf' );
+        $this->label    = sprintf( __( "Url (%s)", 'qtranslate' ), "qTranslate-XT" );
+        $this->category = "qTranslate-XT";
         $this->defaults = array(
             'default_value' => '',
             'placeholder'   => '',

--- a/modules/acf/src/acf_5/fields/url.php
+++ b/modules/acf/src/acf_5/fields/url.php
@@ -28,7 +28,7 @@ class acf_qtranslate_acf_5_url extends acf_field_url {
      */
     function initialize() {
         $this->name     = 'qtranslate_url';
-        $this->label    = sprintf( __( "Url (%s)", 'qtranslate' ), "qTranslate-XT" );
+        $this->label    = __( "Url", 'acf' ) . " (qTranslate-XT)";
         $this->category = "qTranslate-XT";
         $this->defaults = array(
             'default_value' => '',

--- a/modules/acf/src/acf_5/fields/wysiwyg.php
+++ b/modules/acf/src/acf_5/fields/wysiwyg.php
@@ -129,10 +129,10 @@ class acf_qtranslate_acf_5_wysiwyg extends acf_field_wysiwyg {
                         <div class="wp-editor-tabs">
                             <button id="<?php echo $id; ?>-tmce"
                                     class="wp-switch-editor switch-tmce" <?php echo $button; ?>
-                                    type="button"><?php echo __( 'Visual', 'qtranslate' ); ?></button>
+                                    type="button"><?php echo __( 'Visual', 'acf' ); ?></button>
                             <button id="<?php echo $id; ?>-html"
                                     class="wp-switch-editor switch-html" <?php echo $button; ?>
-                                    type="button"><?php echo _x( 'Text', 'Name for the Text editor tab (formerly HTML)', 'qtranslate' ); ?></button>
+                                    type="button"><?php echo _x( 'Text', 'Name for the Text editor tab (formerly HTML)', 'acf' ); ?></button>
                         </div>
                     <?php endif; ?>
                 </div>

--- a/modules/acf/src/acf_5/fields/wysiwyg.php
+++ b/modules/acf/src/acf_5/fields/wysiwyg.php
@@ -28,7 +28,7 @@ class acf_qtranslate_acf_5_wysiwyg extends acf_field_wysiwyg {
      */
     function initialize() {
         $this->name     = 'qtranslate_wysiwyg';
-        $this->label    = sprintf( __( "Wysiwyg Editor (%s)", 'qtranslate' ), "qTranslate-XT" );
+        $this->label    = __( "Wysiwyg Editor", 'acf' ) . " (qTranslate-XT)";
         $this->category = "qTranslate-XT";
         $this->defaults = array(
             'tabs'          => 'all',

--- a/modules/acf/src/acf_5/fields/wysiwyg.php
+++ b/modules/acf/src/acf_5/fields/wysiwyg.php
@@ -28,8 +28,8 @@ class acf_qtranslate_acf_5_wysiwyg extends acf_field_wysiwyg {
      */
     function initialize() {
         $this->name     = 'qtranslate_wysiwyg';
-        $this->label    = __( "Wysiwyg Editor (qTranslate)", 'acf' );
-        $this->category = __( "qTranslate", 'acf' );
+        $this->label    = sprintf( __( "Wysiwyg Editor (%s)", 'qtranslate' ), "qTranslate-XT" );
+        $this->category = "qTranslate-XT";
         $this->defaults = array(
             'tabs'          => 'all',
             'toolbar'       => 'full',
@@ -129,10 +129,10 @@ class acf_qtranslate_acf_5_wysiwyg extends acf_field_wysiwyg {
                         <div class="wp-editor-tabs">
                             <button id="<?php echo $id; ?>-tmce"
                                     class="wp-switch-editor switch-tmce" <?php echo $button; ?>
-                                    type="button"><?php echo __( 'Visual', 'acf' ); ?></button>
+                                    type="button"><?php echo __( 'Visual', 'qtranslate' ); ?></button>
                             <button id="<?php echo $id; ?>-html"
                                     class="wp-switch-editor switch-html" <?php echo $button; ?>
-                                    type="button"><?php echo _x( 'Text', 'Name for the Text editor tab (formerly HTML)', 'acf' ); ?></button>
+                                    type="button"><?php echo _x( 'Text', 'Name for the Text editor tab (formerly HTML)', 'qtranslate' ); ?></button>
                         </div>
                     <?php endif; ?>
                 </div>

--- a/modules/acf/src/plugin.php
+++ b/modules/acf/src/plugin.php
@@ -403,7 +403,7 @@ class acf_qtranslate_plugin {
         foreach ( $values as $key_language => $value_language ) {
             // validate properly the required value (see: acf_validate_value in acf_validation)
             if ( $field['required'] && empty( $value_language ) ) {
-                return '(' . $q_config['language_name'][ $key_language ] . ') ' . sprintf( __( '%s value is required', 'qtranslate' ), $field['label'] );
+                return '(' . $q_config['language_name'][ $key_language ] . ') ' . sprintf( __( '%s value is required', 'acf' ), $field['label'] );
             }
             // validate with original ACF method
             if ( isset( $validation_method ) ) {

--- a/modules/acf/src/plugin.php
+++ b/modules/acf/src/plugin.php
@@ -403,7 +403,7 @@ class acf_qtranslate_plugin {
         foreach ( $values as $key_language => $value_language ) {
             // validate properly the required value (see: acf_validate_value in acf_validation)
             if ( $field['required'] && empty( $value_language ) ) {
-                return '(' . $q_config['language_name'][ $key_language ] . ') ' . sprintf( __( '%s value is required', 'acf' ), $field['label'] );
+                return '(' . $q_config['language_name'][ $key_language ] . ') ' . sprintf( __( '%s value is required', 'qtranslate' ), $field['label'] );
             }
             // validate with original ACF method
             if ( isset( $validation_method ) ) {


### PR DESCRIPTION
~Localize strings of the ACF module in domain qtranslate (previously in acf).~
~No i18n translations were found in the legacy acf-qtranslate project.~

qTranslate should not add new strings to `acf`. 