### PR TITLE
Remove `hreflang` from `a` tag in widget

### DIFF
--- a/qtranslate_widget.php
+++ b/qtranslate_widget.php
@@ -246,8 +246,6 @@ function qtranxf_generateLanguageSelectCode( $args = array(), $id = '' ) {
                         $classes[] = 'active';
                     }
                     echo '<li class="' . implode( ' ', $classes ) . '"><a href="' . qtranxf_convertURL( $url, $language, false, true ) . '"';
-                    // set hreflang
-                    echo ' hreflang="' . $language . '"';
                     echo ' title="' . $alt . '"';
                     if ( $type == 'image' ) {
                         echo ' class="qtranxs_image qtranxs_image_' . $language . '"';


### PR DESCRIPTION
There's no need to set hreflang in "a" tag, since we have "link" tags with hreflang in "head" of the website.

I have digged all around the network and didn't find any information about using hreflang attribute inside of "a" tags.