### PR TITLE
Fixed an issue when trying to translate a GF choice text value

### DIFF
--- a/modules/gravity-forms/gravity-forms.php
+++ b/modules/gravity-forms/gravity-forms.php
@@ -65,7 +65,11 @@ class qTranslateSupportForGravityforms {
                 // Support for the poll add-on
                 if ( isset( $form['fields'][ $id ]->choices ) && $form['fields'][ $id ]->choices ) {
                     foreach ( $form['fields'][ $id ]->choices as $value => $key ) {
-                        $form['fields'][ $id ]['choices'][ $value ]['text'] = $this->translate( $key['text'] );
+                        if ( is_object( $form['fields'][ $id ] ) ) {
+                            $form['fields'][ $id ]->choices[ $value ]['text'] = $this->translate( $key['text'] );
+                        } else {
+                            $form['fields'][ $id ]['choices'][ $value ]['text'] = $this->translate( $key['text'] );
+                        }
                     }
                 }
                 if ( isset( $form['fields'][ $id ]->nextButton ) && $form['fields'][ $id ]->nextButton ) {


### PR DESCRIPTION
This fixes a notice that is being triggered by updating a Gravity Form choice as an array even though it's a class.
And it will also make sure if it's an object or not (so that legacy versions will keep working).
Before this change on certain PHP versions the following notice will be triggered:

```
Indirect modification of overloaded element of GF_Field_Checkbox has no effect
```