### PR TITLE
QTS: Use $post object instead of $_POST array

### DIFF
--- a/modules/slugs/includes/class-qtranslate-slug.php
+++ b/modules/slugs/includes/class-qtranslate-slug.php
@@ -2420,5 +2420,3 @@ class QtranslateSlug {
         return $html;
     }
 }
-
-?>

--- a/modules/slugs/includes/class-qtranslate-slug.php
+++ b/modules/slugs/includes/class-qtranslate-slug.php
@@ -1513,7 +1513,7 @@ class QtranslateSlug {
      */
     public function validate_post_slug( $slug, $post, $lang ) {
 
-        $post_title = trim( call_user_func( $this->get_plugin_prefix() . 'use', $lang, $_POST['post_title'] ) );
+        $post_title = trim(call_user_func($this->get_plugin_prefix() . 'use',$lang, $post->post_title));
         $post_name  = get_post_meta( $post->ID, $this->get_meta_key( $lang ), true );
         if ( ! $post_name ) {
             $post_name = $post->post_name;
@@ -2698,3 +2698,5 @@ class QtranslateSlug {
         return $html;
     }
 }
+
+?>


### PR DESCRIPTION
Use $post->post_title instead of $_POST['post_title']

WordPress 5.0.3/PHP-7.3.1