### PR TITLE
Refactor module activation handler and options

### DIFF
--- a/admin/qtx_activation_hook.php
+++ b/admin/qtx_activation_hook.php
@@ -832,7 +832,7 @@ function qtranxf_activation_hook() {
     // After reactivation the enabled modules are reloaded, but all the conditions are checked with all plugins again.
     global $qtranslate_options;
     qtranxf_admin_set_default_options( $qtranslate_options );
-    qtranxf_load_option_array( 'modules_ma_enabled', $qtranslate_options['admin']['modules_ma_enabled'] );
+    qtranxf_load_option_array( 'admin_enabled_modules', $qtranslate_options['admin']['admin_enabled_modules'] );
     QTX_Admin_Modules::update_modules_status();
 
     /**

--- a/admin/qtx_activation_hook.php
+++ b/admin/qtx_activation_hook.php
@@ -833,7 +833,7 @@ function qtranxf_activation_hook() {
     global $qtranslate_options;
     qtranxf_admin_set_default_options( $qtranslate_options );
     qtranxf_load_option_array( 'admin_enabled_modules', $qtranslate_options['admin']['admin_enabled_modules'] );
-    QTX_Admin_Modules::update_modules_status();
+    QTX_Admin_Modules::update_modules_state();
 
     /**
      * A chance to execute activation actions specifically for this plugin.

--- a/admin/qtx_activation_hook.php
+++ b/admin/qtx_activation_hook.php
@@ -827,6 +827,12 @@ function qtranxf_activation_hook() {
         qtranxf_update_option_admin_notices( $messages, 'gutenberg-support', false );
     }
 
+    // To initialize the modules state we need the default enabled modules but the `q_config` has not been loaded yet.
+    // For the first activation, the default options are used.
+    // After reactivation the enabled modules are reloaded, but all the conditions are checked with all plugins again.
+    global $qtranslate_options;
+    qtranxf_admin_set_default_options( $qtranslate_options );
+    qtranxf_load_option_array( 'modules_ma_enabled', $qtranslate_options['admin']['modules_ma_enabled'] );
     QTX_Admin_Modules::update_modules_status();
 
     /**

--- a/admin/qtx_admin_modules.php
+++ b/admin/qtx_admin_modules.php
@@ -186,9 +186,8 @@ class QTX_Admin_Modules {
         $infos           = array();
         foreach ( $module_defs as $module_def ) {
             $info           = array();
-            $info['id']     = $module_def['id'];
-            $info['name']   = $module_def['name'];
-            $info['status'] = array_key_exists( $module_def['id'], $options_modules ) ? $options_modules[ $module_def['id'] ] : QTX_MODULE_STATUS_UNDEFINED;
+            $info['def']    = $module_def;
+            $info['status'] = isset( $options_modules[ $module_def['id'] ] ) ? $options_modules[ $module_def['id'] ] : QTX_MODULE_STATUS_UNDEFINED;
             $info['plugin'] = $module_def['plugin'] === true ? '-' : ( self::is_module_plugin_active( $module_def ) ? __( 'Active', 'qtranslate' ) : __( 'Inactive', 'qtranslate' ) );
             switch ( $info['status'] ) {
                 case QTX_MODULE_STATUS_ACTIVE:

--- a/admin/qtx_admin_modules.php
+++ b/admin/qtx_admin_modules.php
@@ -13,19 +13,23 @@ class QTX_Admin_Modules {
 
     /**
      * Update the modules status for plugin integration.
+     *
+     * Each module is activated:
+     * - if the conditions with integration and incompatible plugins (optional) are met
+     * AND
+     * - if the `modules_ma_enabled` admin option is checked for that module.
+     *
      * The valid modules are stored in the 'qtranslate_modules' option, telling which module should be loaded.
      * Note each module can enable hooks both for admin and front requests.
      *
      * @param callable $func_is_active callback to evaluate if a plugin is active
      */
     public static function update_modules_status( $func_is_active = 'is_plugin_active' ) {
-        require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
-
         global $q_config;
 
-        $module_defs    = QTX_Modules_Handler::get_modules_defs();
         $option_modules = array();
-        foreach ( $module_defs as $module_def ) {
+        require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+        foreach ( QTX_Modules_Handler::get_modules_defs() as $module_def ) {
             $status = self::can_module_be_activated( $module_def, $func_is_active );
             if ( $status == QTX_MODULE_STATUS_ACTIVE ) {
                 // The admin options matter only if the module can be activated, otherwise the hard conditions prevail.

--- a/admin/qtx_admin_modules.php
+++ b/admin/qtx_admin_modules.php
@@ -46,6 +46,7 @@ class QTX_Admin_Modules {
         // trigger info notices only if changed
         if ( $old_option_modules != $option_modules ) {
             set_transient( 'qtranslate_notice_modules', true, 5 );
+            QTX_Modules_Handler::load_active_modules();
         }
     }
 

--- a/admin/qtx_admin_modules.php
+++ b/admin/qtx_admin_modules.php
@@ -187,20 +187,20 @@ class QTX_Admin_Modules {
             $info           = array();
             $info['def']    = $module_def;
             $info['state']  = isset( $options_modules[ $module_def['id'] ] ) ? $options_modules[ $module_def['id'] ] : QTX_MODULE_STATE_UNDEFINED;
-            $info['plugin'] = $module_def['plugin'] === true ? '-' : ( self::is_module_plugin_active( $module_def ) ? __( 'Active', 'qtranslate' ) : __( 'Inactive', 'qtranslate' ) );
+            $info['plugin'] = $module_def['plugin'] === true ? _x( 'None', 'Module admin', 'qtranslate' ) : ( self::is_module_plugin_active( $module_def ) ? _x( 'Active', 'Module admin', 'qtranslate' ) : _x( 'Inactive', 'Module admin', 'qtranslate' ) );
             switch ( $info['state'] ) {
                 case QTX_MODULE_STATE_ACTIVE:
-                    $info['module'] = __( 'Active', 'qtranslate' );
+                    $info['module'] = _x( 'Active', 'Module admin', 'qtranslate' );
                     $info['icon']   = 'dashicons-yes';
                     $info['color']  = 'green';
                     break;
                 case QTX_MODULE_STATE_INACTIVE:
-                    $info['module'] = __( 'Inactive', 'qtranslate' );
+                    $info['module'] = _x( 'Inactive', 'Module admin', 'qtranslate' );
                     $info['icon']   = 'dashicons-no-alt';
                     $info['color']  = '';
                     break;
                 case QTX_MODULE_STATE_BLOCKED:
-                    $info['module'] = __( 'Blocked', 'qtranslate' );
+                    $info['module'] = _x( 'Blocked', 'Module admin', 'qtranslate' );
                     $info['icon']   = 'dashicons-warning';
                     $info['color']  = 'orange';
                     break;

--- a/admin/qtx_admin_modules.php
+++ b/admin/qtx_admin_modules.php
@@ -28,17 +28,11 @@ class QTX_Admin_Modules {
         foreach ( $module_defs as $module_def ) {
             $status = self::can_module_be_activated( $module_def, $func_is_active );
             if ( $status == QTX_MODULE_STATUS_ACTIVE ) {
-                // The admin checkboxes are not sent in the POST message on update, enforce default values to `false` here.
-                if ( ! isset ( $q_config['modules_ma_enabled'][ $module_def['id'] ] ) ) {
-                    $q_config['modules_ma_enabled'][ $module_def['id'] ] = false;
-                }
-
-                // Note the module may also be disabled manually from before the current update.
-                if ( ! $q_config['modules_ma_enabled'][ $module_def['id'] ] ) {
+                // The admin options matter only if the module can be activated, otherwise the hard conditions prevail.
+                if ( isset ( $q_config['modules_ma_enabled'][ $module_def['id'] ] ) && ! $q_config['modules_ma_enabled'][ $module_def['id'] ] ) {
                     $status = QTX_MODULE_STATUS_INACTIVE;
                 }
             }
-
             $option_modules[ $module_def['id'] ] = $status;
         }
 

--- a/admin/qtx_admin_modules.php
+++ b/admin/qtx_admin_modules.php
@@ -12,36 +12,36 @@ class QTX_Admin_Modules {
     }
 
     /**
-     * Update the modules status for plugin integration.
+     * Update the state of all modules for plugin integration.
      *
      * Each module is activated:
      * - if the conditions with integration and incompatible plugins (optional) are met
      * AND
      * - if the `admin_enabled_modules` admin option is checked for that module.
      *
-     * The valid modules are stored in the 'qtranslate_modules' option, telling which module should be loaded.
+     * Update the 'qtranslate_modules_state' option, telling which module should be loaded.
      * Note each module can enable hooks both for admin and front requests.
      *
      * @param callable $func_is_active callback to evaluate if a plugin is active
      */
-    public static function update_modules_status( $func_is_active = 'is_plugin_active' ) {
+    public static function update_modules_state( $func_is_active = 'is_plugin_active' ) {
         global $q_config;
 
         $option_modules = array();
         require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
         foreach ( QTX_Modules_Handler::get_modules_defs() as $module_def ) {
-            $status = self::can_module_be_activated( $module_def, $func_is_active );
-            if ( $status == QTX_MODULE_STATUS_ACTIVE ) {
+            $state = self::can_module_be_activated( $module_def, $func_is_active );
+            if ( $state == QTX_MODULE_STATE_ACTIVE ) {
                 // The admin options matter only if the module can be activated, otherwise the hard conditions prevail.
                 if ( isset ( $q_config['admin_enabled_modules'][ $module_def['id'] ] ) && ! $q_config['admin_enabled_modules'][ $module_def['id'] ] ) {
-                    $status = QTX_MODULE_STATUS_INACTIVE;
+                    $state = QTX_MODULE_STATE_INACTIVE;
                 }
             }
-            $option_modules[ $module_def['id'] ] = $status;
+            $option_modules[ $module_def['id'] ] = $state;
         }
 
-        $old_option_modules = get_option( 'qtranslate_modules' );
-        update_option( 'qtranslate_modules', $option_modules );
+        $old_option_modules = get_option( 'qtranslate_modules_state' );
+        update_option( 'qtranslate_modules_state', $option_modules );
 
         // trigger info notices only if changed
         if ( $old_option_modules != $option_modules ) {
@@ -91,21 +91,21 @@ class QTX_Admin_Modules {
      * @param array $module_def
      * @param callable $func_is_active callback to evaluate if a plugin is active
      *
-     * @return integer module status
+     * @return integer module state
      */
     public static function can_module_be_activated( $module_def, $func_is_active = 'is_plugin_active' ) {
-        $module_status = QTX_MODULE_STATUS_INACTIVE;
+        $state = QTX_MODULE_STATE_INACTIVE;
 
         $active = self::is_module_plugin_active( $module_def, $func_is_active );
         if ( $active ) {
             if ( isset( $module_def['incompatible'] ) && call_user_func( $func_is_active, $module_def['incompatible'] ) ) {
-                $module_status = QTX_MODULE_STATUS_BLOCKED;
+                $state = QTX_MODULE_STATE_BLOCKED;
             } else {
-                $module_status = QTX_MODULE_STATUS_ACTIVE;
+                $state = QTX_MODULE_STATE_ACTIVE;
             }
         }
 
-        return $module_status;
+        return $state;
     }
 
     /**
@@ -116,7 +116,7 @@ class QTX_Admin_Modules {
     public static function register_plugin_activated( $updated_plugin ) {
         // we could use "is_plugin_active" because the "active_plugins" option is updated BEFORE the action is called
         // however this is not the case for the deactivation so for consistency we use the counterpart check
-        self::update_modules_status( function ( $test_plugin ) use ( $updated_plugin ) {
+        self::update_modules_state( function ( $test_plugin ) use ( $updated_plugin ) {
             return ( $test_plugin === $updated_plugin ) ? true : is_plugin_active( $test_plugin );
         } );
     }
@@ -129,15 +129,15 @@ class QTX_Admin_Modules {
     public static function register_plugin_deactivated( $updated_plugin ) {
         // we can't use "is_plugin_active" because the "active_plugins" option is updated AFTER the action is called!
         // this is a problem of WP Core, but we pass a custom function as a workaround
-        self::update_modules_status( function ( $test_plugin ) use ( $updated_plugin ) {
+        self::update_modules_state( function ( $test_plugin ) use ( $updated_plugin ) {
             return ( $test_plugin === $updated_plugin ) ? false : is_plugin_active( $test_plugin );
         } );
     }
 
     public static function admin_notices() {
-        $options_modules = get_option( 'qtranslate_modules', array() );
+        $options_modules = get_option( 'qtranslate_modules_state', array() );
         if ( empty( $options_modules ) ) {
-            $msg   = '<p>' . sprintf( __( 'Modules status undefined in %s. Please deactivate it and reactivate it again from the plugins page.', 'qtranslate' ), 'qTranslate&#8209;XT' ) . '</p>';
+            $msg   = '<p>' . sprintf( __( 'Modules state undefined in %s. Please deactivate it and reactivate it again from the plugins page.', 'qtranslate' ), 'qTranslate&#8209;XT' ) . '</p>';
             $nonce = wp_create_nonce( 'deactivate-plugin_qtranslate-xt/qtranslate.php' );
             $msg   .= '<p><a class="button" href="' . admin_url( 'plugins.php?action=deactivate&plugin=' . urlencode( 'qtranslate-xt/qtranslate.php' ) . '&plugin_status=all&paged=1&s&_wpnonce=' . $nonce ) . '"><strong>' . sprintf( __( 'Deactivate %s', 'qtranslate' ), 'qTranslate&#8209;XT' ) . '</strong></a></p>';
             echo '<div class="notice notice-warning is-dismissible">' . $msg . '</div>';
@@ -153,7 +153,7 @@ class QTX_Admin_Modules {
             }
 
             switch ( $options_modules[ $module_def['id'] ] ) {
-                case QTX_MODULE_STATUS_BLOCKED:
+                case QTX_MODULE_STATE_BLOCKED:
                     $incompatible_plugin = $module_def['incompatible'];
                     $plugin_data         = get_plugin_data( WP_PLUGIN_DIR . '/' . $incompatible_plugin, false, true );
                     $plugin_name         = $plugin_data['Name'];
@@ -162,7 +162,7 @@ class QTX_Admin_Modules {
                     $msg                 .= '<p><a class="button" href="' . $url_deactivate . '"><strong>' . sprintf( __( 'Deactivate plugin %s', 'qtranslate' ), $plugin_name ) . '</strong></a>';
                     echo '<div class="notice notice-warning is-dismissible">' . $msg . '</div>';
                     break;
-                case QTX_MODULE_STATUS_ACTIVE:
+                case QTX_MODULE_STATE_ACTIVE:
                     $active_modules[] = $module_def['name'];
                     break;
             }
@@ -181,30 +181,30 @@ class QTX_Admin_Modules {
      */
     public static function get_modules_infos() {
         $module_defs     = QTX_Modules_Handler::get_modules_defs();
-        $options_modules = get_option( 'qtranslate_modules', array() );
+        $options_modules = get_option( 'qtranslate_modules_state', array() );
         $infos           = array();
         foreach ( $module_defs as $module_def ) {
             $info           = array();
             $info['def']    = $module_def;
-            $info['status'] = isset( $options_modules[ $module_def['id'] ] ) ? $options_modules[ $module_def['id'] ] : QTX_MODULE_STATUS_UNDEFINED;
+            $info['state']  = isset( $options_modules[ $module_def['id'] ] ) ? $options_modules[ $module_def['id'] ] : QTX_MODULE_STATE_UNDEFINED;
             $info['plugin'] = $module_def['plugin'] === true ? '-' : ( self::is_module_plugin_active( $module_def ) ? __( 'Active', 'qtranslate' ) : __( 'Inactive', 'qtranslate' ) );
-            switch ( $info['status'] ) {
-                case QTX_MODULE_STATUS_ACTIVE:
+            switch ( $info['state'] ) {
+                case QTX_MODULE_STATE_ACTIVE:
                     $info['module'] = __( 'Active', 'qtranslate' );
                     $info['icon']   = 'dashicons-yes';
                     $info['color']  = 'green';
                     break;
-                case QTX_MODULE_STATUS_INACTIVE:
+                case QTX_MODULE_STATE_INACTIVE:
                     $info['module'] = __( 'Inactive', 'qtranslate' );
                     $info['icon']   = 'dashicons-no-alt';
                     $info['color']  = '';
                     break;
-                case QTX_MODULE_STATUS_BLOCKED:
+                case QTX_MODULE_STATE_BLOCKED:
                     $info['module'] = __( 'Blocked', 'qtranslate' );
                     $info['icon']   = 'dashicons-warning';
                     $info['color']  = 'orange';
                     break;
-                case QTX_MODULE_STATUS_UNDEFINED:
+                case QTX_MODULE_STATE_UNDEFINED:
                 default:
                     $info['module'] = __( 'Inactive', 'qtranslate' );
                     $info['icon']   = 'dashicons-editor-help';

--- a/admin/qtx_admin_modules.php
+++ b/admin/qtx_admin_modules.php
@@ -17,7 +17,7 @@ class QTX_Admin_Modules {
      * Each module is activated:
      * - if the conditions with integration and incompatible plugins (optional) are met
      * AND
-     * - if the `modules_ma_enabled` admin option is checked for that module.
+     * - if the `admin_enabled_modules` admin option is checked for that module.
      *
      * The valid modules are stored in the 'qtranslate_modules' option, telling which module should be loaded.
      * Note each module can enable hooks both for admin and front requests.
@@ -33,7 +33,7 @@ class QTX_Admin_Modules {
             $status = self::can_module_be_activated( $module_def, $func_is_active );
             if ( $status == QTX_MODULE_STATUS_ACTIVE ) {
                 // The admin options matter only if the module can be activated, otherwise the hard conditions prevail.
-                if ( isset ( $q_config['modules_ma_enabled'][ $module_def['id'] ] ) && ! $q_config['modules_ma_enabled'][ $module_def['id'] ] ) {
+                if ( isset ( $q_config['admin_enabled_modules'][ $module_def['id'] ] ) && ! $q_config['admin_enabled_modules'][ $module_def['id'] ] ) {
                     $status = QTX_MODULE_STATUS_INACTIVE;
                 }
             }

--- a/admin/qtx_admin_options.php
+++ b/admin/qtx_admin_options.php
@@ -36,8 +36,14 @@ function qtranxf_admin_set_default_options( &$options ) {
         'custom_fields'        => array(),
         'custom_field_classes' => array(),
         'post_type_excluded'   => array(),
-        'modules_ma_enabled'   => array()
     );
+
+    // Boolean set defining the default enabled options for each module, hard values not depending on any state.
+    $options['admin']['modules_ma_enabled'] = array();
+    foreach ( QTX_Modules_Handler::get_modules_defs() as $module_def ) {
+        // TODO: expand default values in module def
+        $options['admin']['modules_ma_enabled'][ $module_def['id'] ] = ( $module_def['plugin'] !== true );
+    }
 
     // options processed in a special way
     $options = apply_filters( 'qtranslate_option_config_admin', $options );
@@ -71,6 +77,8 @@ function qtranxf_admin_load_config() {
     foreach ( $qtranslate_options['admin']['array'] as $name => $default ) {
         qtranxf_load_option_array( $name, $default );
     }
+
+    qtranxf_load_option_array( 'modules_ma_enabled', $qtranslate_options['admin']['modules_ma_enabled'] );
 
     if ( empty( $q_config['admin_config'] ) ) {
         require_once( QTRANSLATE_DIR . '/admin/qtx_admin_options_update.php' );

--- a/admin/qtx_admin_options.php
+++ b/admin/qtx_admin_options.php
@@ -39,10 +39,10 @@ function qtranxf_admin_set_default_options( &$options ) {
     );
 
     // Boolean set defining the default enabled options for each module, hard values not depending on any state.
-    $options['admin']['modules_ma_enabled'] = array();
+    $options['admin']['admin_enabled_modules'] = array();
     foreach ( QTX_Modules_Handler::get_modules_defs() as $module_def ) {
         // TODO: expand default values in module def
-        $options['admin']['modules_ma_enabled'][ $module_def['id'] ] = ( $module_def['plugin'] !== true );
+        $options['admin']['admin_enabled_modules'][ $module_def['id'] ] = ( $module_def['plugin'] !== true );
     }
 
     // options processed in a special way
@@ -78,7 +78,7 @@ function qtranxf_admin_load_config() {
         qtranxf_load_option_array( $name, $default );
     }
 
-    qtranxf_load_option_array( 'modules_ma_enabled', $qtranslate_options['admin']['modules_ma_enabled'] );
+    qtranxf_load_option_array( 'admin_enabled_modules', $qtranslate_options['admin']['admin_enabled_modules'] );
 
     if ( empty( $q_config['admin_config'] ) ) {
         require_once( QTRANSLATE_DIR . '/admin/qtx_admin_options_update.php' );

--- a/admin/qtx_admin_options.php
+++ b/admin/qtx_admin_options.php
@@ -36,6 +36,7 @@ function qtranxf_admin_set_default_options( &$options ) {
         'custom_fields'        => array(),
         'custom_field_classes' => array(),
         'post_type_excluded'   => array(),
+        'modules_ma_enabled'   => array()
     );
 
     // options processed in a special way

--- a/admin/qtx_admin_options_update.php
+++ b/admin/qtx_admin_options_update.php
@@ -359,7 +359,7 @@ function qtranxf_reset_config() {
     // internal private options not loaded by default
     delete_option( 'qtranslate_next_update_mo' );
     delete_option( 'qtranslate_next_thanks' );
-    delete_option( 'qtranslate_modules' );
+    delete_option( 'qtranslate_modules_state' );
 
     // obsolete options
     delete_option( 'qtranslate_custom_pages' );
@@ -378,7 +378,7 @@ function qtranxf_reset_config() {
     qtranxf_reload_config();
     add_filter( 'locale', 'qtranxf_localeForCurrentLanguage', 99 );
 
-    QTX_Admin_Modules::update_modules_status();
+    QTX_Admin_Modules::update_modules_state();
 }
 
 add_action( 'qtranslate_save_config', 'qtranxf_reset_config', 20 );
@@ -943,7 +943,7 @@ function qtranxf_update_settings() {
 
     qtranxf_update_setting( 'admin_enabled_modules', QTX_BOOLEAN_SET, $qtranslate_options['admin']['admin_enabled_modules'] );
 
-    QTX_Admin_Modules::update_modules_status();
+    QTX_Admin_Modules::update_modules_state();
 
     // opportunity to update special custom settings on sub-plugins
     do_action( 'qtranslate_update_settings' );

--- a/admin/qtx_admin_options_update.php
+++ b/admin/qtx_admin_options_update.php
@@ -941,6 +941,8 @@ function qtranxf_update_settings() {
 
     $q_config['i18n-cache'] = array(); // clear i18n-config cache
 
+    qtranxf_update_setting( 'modules_ma_enabled', QTX_BOOLEAN_SET, $qtranslate_options['admin']['modules_ma_enabled'] );
+
     QTX_Admin_Modules::update_modules_status();
 
     // opportunity to update special custom settings on sub-plugins

--- a/admin/qtx_admin_options_update.php
+++ b/admin/qtx_admin_options_update.php
@@ -494,8 +494,6 @@ function qtranxf_save_config() {
         qtranxf_update_option( $nm, $def );
     }
 
-    QTX_Admin_Modules::update_manual_enabled_modules();
-
     do_action( 'qtranslate_save_config' );
     do_action_deprecated( 'qtranslate_saveConfig', array(), '3.10.0', 'qtranslate_save_config' );
 }
@@ -816,7 +814,6 @@ function qtranxf_update_settings() {
         qtranxf_update_setting( $name, QTX_ARRAY, $default );
     }
     qtranxf_update_setting( 'filter_options', QTX_ARRAY );
-    qtranxf_update_setting( 'ma_module_enabled', QTX_ARRAY, null, true );
 
     switch ( $q_config['url_mode'] ) {
         case QTX_URL_DOMAIN:
@@ -924,6 +921,8 @@ function qtranxf_update_settings() {
     }
 
     $q_config['i18n-cache'] = array(); // clear i18n-config cache
+
+    QTX_Admin_Modules::update_modules_status();
 
     // opportunity to update special custom settings on sub-plugins
     do_action( 'qtranslate_update_settings' );

--- a/admin/qtx_admin_options_update.php
+++ b/admin/qtx_admin_options_update.php
@@ -941,7 +941,7 @@ function qtranxf_update_settings() {
 
     $q_config['i18n-cache'] = array(); // clear i18n-config cache
 
-    qtranxf_update_setting( 'modules_ma_enabled', QTX_BOOLEAN_SET, $qtranslate_options['admin']['modules_ma_enabled'] );
+    qtranxf_update_setting( 'admin_enabled_modules', QTX_BOOLEAN_SET, $qtranslate_options['admin']['admin_enabled_modules'] );
 
     QTX_Admin_Modules::update_modules_status();
 

--- a/admin/qtx_admin_settings.php
+++ b/admin/qtx_admin_settings.php
@@ -724,15 +724,15 @@ class QTX_Admin_Settings {
                             <th class="row-title"><?php _ex( 'Name', 'Modules table header', 'qtranslate' ); ?></th>
                             <th><?php _ex( 'Plugin', 'Modules table header', 'qtranslate' ); ?></th>
                             <th><?php _ex( 'Module', 'Modules table header', 'qtranslate' ); ?></th>
-                            <th><?php _ex( 'Status', 'Modules table header', 'qtranslate' ); ?></th>
+                            <th><?php _ex( 'State', 'Modules table header', 'qtranslate' ); ?></th>
                         </tr>
                         </thead>
                         <tbody>
                         <?php
                         foreach ( QTX_Admin_Modules::get_modules_infos() as $module ) :
                             $module_id = $module['def']['id'];
-                            $module_is_checked = ( isset( $q_config['admin_enabled_modules'][ $module_id ] ) && $q_config['admin_enabled_modules'][ $module_id ] ) || ( $module['status'] == QTX_MODULE_STATUS_ACTIVE );
-                            $module_is_disabled = ( QTX_Admin_Modules::can_module_be_activated( $module['def'] ) != QTX_MODULE_STATUS_ACTIVE );
+                            $module_is_checked = ( isset( $q_config['admin_enabled_modules'][ $module_id ] ) && $q_config['admin_enabled_modules'][ $module_id ] ) || ( $module['state'] == QTX_MODULE_STATE_ACTIVE );
+                            $module_is_disabled = ( QTX_Admin_Modules::can_module_be_activated( $module['def'] ) != QTX_MODULE_STATE_ACTIVE );
                             ?>
                             <tr>
                                 <td>

--- a/admin/qtx_admin_settings.php
+++ b/admin/qtx_admin_settings.php
@@ -729,18 +729,19 @@ class QTX_Admin_Settings {
                         </thead>
                         <tbody>
                         <?php
-                        global $q_config;
-                        foreach ( QTX_Admin_Modules::get_modules_infos() as $module ):
+                        $modules = QTX_Admin_Modules::get_modules_infos();
+                        foreach ( $modules as $module ):
+                            $module_id = $module['id'];
                             // TODO: allow custom default value by module
-                            $module_is_checked = isset( $q_config['modules_ma_enabled'][ $module['id'] ] ) && $q_config['modules_ma_enabled'][ $module['id'] ];
-                            $module_is_disabled = QTX_Admin_Modules::can_module_be_activated( QTX_Modules_Handler::get_module_def_by_id( $module['id'] ) ) != QTX_MODULE_STATUS_ACTIVE;
+                            $module_is_checked  = isset( $q_config['modules_ma_enabled'][ $module_id ] ) && $q_config['modules_ma_enabled'][ $module_id ];
+                            $module_is_disabled = QTX_Admin_Modules::can_module_be_activated( QTX_Modules_Handler::get_module_def_by_id( $module_id ) ) != QTX_MODULE_STATUS_ACTIVE;
                             ?>
                             <tr>
                                 <td>
-                                    <label for="modules_ma_enabled_<?php echo $module['id']; ?>">
+                                    <label for="modules_ma_enabled_<?php echo $module_id; ?>">
                                         <input type="checkbox"
-                                               name="modules_ma_enabled[<?php echo $module['id']; ?>]"
-                                               id="modules_ma_enabled_<?php echo $module['id']; ?>"
+                                               name="modules_ma_enabled[<?php echo $module_id; ?>]"
+                                               id="modules_ma_enabled_<?php echo $module_id; ?>"
                                                value="1"<?php checked( $module_is_checked );
                                         disabled( $module_is_disabled ) ?>/>
                                         <?php echo $module['name']; ?>

--- a/admin/qtx_admin_settings.php
+++ b/admin/qtx_admin_settings.php
@@ -743,12 +743,6 @@ class QTX_Admin_Settings {
                                     <label for="admin_enabled_modules_<?php echo $module_id; ?>">
                                         <?php echo $module['def']['name']; ?>
                                     </label>
-                                    <input type="checkbox"
-                                           name="admin_enabled_modules[<?php echo $module_id; ?>]"
-                                           id="admin_enabled_modules_<?php echo $module_id; ?>"
-                                           value="1"<?php checked( $module_is_checked );
-                                    disabled( $module_is_disabled ) ?>/>
-                                    <?php echo $module['def']['name']; ?>
                                 </td>
                                 <td><?php echo $module['plugin'] ?></td>
                                 <td style="color: <?php echo $module['color'] ?>">

--- a/admin/qtx_admin_settings.php
+++ b/admin/qtx_admin_settings.php
@@ -729,23 +729,21 @@ class QTX_Admin_Settings {
                         </thead>
                         <tbody>
                         <?php
-                        $modules = QTX_Admin_Modules::get_modules_infos();
-                        foreach ( $modules as $module ):
-                            $module_id = $module['id'];
-                            // TODO: allow custom default value by module
-                            $module_is_checked  = isset( $q_config['modules_ma_enabled'][ $module_id ] ) && $q_config['modules_ma_enabled'][ $module_id ];
-                            $module_is_disabled = QTX_Admin_Modules::can_module_be_activated( QTX_Modules_Handler::get_module_def_by_id( $module_id ) ) != QTX_MODULE_STATUS_ACTIVE;
+                        foreach ( QTX_Admin_Modules::get_modules_infos() as $module ) :
+                            $module_id = $module['def']['id'];
+                            $module_is_checked = ( isset( $q_config['modules_ma_enabled'][ $module_id ] ) && $q_config['modules_ma_enabled'][ $module_id ] ) || ( $module['status'] == QTX_MODULE_STATUS_ACTIVE );
+                            $module_is_disabled = ( QTX_Admin_Modules::can_module_be_activated( $module['def'] ) != QTX_MODULE_STATUS_ACTIVE );
                             ?>
                             <tr>
                                 <td>
                                     <label for="modules_ma_enabled_<?php echo $module_id; ?>">
-                                        <input type="checkbox"
-                                               name="modules_ma_enabled[<?php echo $module_id; ?>]"
-                                               id="modules_ma_enabled_<?php echo $module_id; ?>"
-                                               value="1"<?php checked( $module_is_checked );
-                                        disabled( $module_is_disabled ) ?>/>
-                                        <?php echo $module['name']; ?>
                                     </label>
+                                    <input type="checkbox"
+                                           name="modules_ma_enabled[<?php echo $module_id; ?>]"
+                                           id="modules_ma_enabled_<?php echo $module_id; ?>"
+                                           value="1"<?php checked( $module_is_checked );
+                                    disabled( $module_is_disabled ) ?>/>
+                                    <?php echo $module['def']['name']; ?>
                                 </td>
                                 <td><?php echo $module['plugin'] ?></td>
                                 <td><?php echo $module['module'] ?></td>

--- a/admin/qtx_admin_settings.php
+++ b/admin/qtx_admin_settings.php
@@ -729,17 +729,19 @@ class QTX_Admin_Settings {
                         </thead>
                         <tbody>
                         <?php
-                        $modules = QTX_Admin_Modules::get_modules_infos();
-                        foreach ( $modules as $module ):
-                            $module_is_disabled = QTX_Admin_Modules::check_module( QTX_Modules_Handler::get_module_def_by_id( $module['id'] ) ) != QTX_MODULE_STATUS_ACTIVE;
+                        global $q_config;
+                        foreach ( QTX_Admin_Modules::get_modules_infos() as $module ):
+                            // TODO: allow custom default value by module
+                            $module_is_checked = isset( $q_config['modules_ma_enabled'][ $module['id'] ] ) && $q_config['modules_ma_enabled'][ $module['id'] ];
+                            $module_is_disabled = QTX_Admin_Modules::can_module_be_activated( QTX_Modules_Handler::get_module_def_by_id( $module['id'] ) ) != QTX_MODULE_STATUS_ACTIVE;
                             ?>
                             <tr>
                                 <td>
-                                    <label for="ma_module_enabled_<?php echo $module['id']; ?>">
+                                    <label for="modules_ma_enabled_<?php echo $module['id']; ?>">
                                         <input type="checkbox"
-                                               name="ma_module_enabled[<?php echo $module['id']; ?>]"
-                                               id="ma_module_enabled_<?php echo $module['id']; ?>"
-                                               value="1"<?php checked( $q_config['ma_module_enabled'][ $module['id'] ] && ! $module_is_disabled );
+                                               name="modules_ma_enabled[<?php echo $module['id']; ?>]"
+                                               id="modules_ma_enabled_<?php echo $module['id']; ?>"
+                                               value="1"<?php checked( $module_is_checked );
                                         disabled( $module_is_disabled ) ?>/>
                                         <?php echo $module['name']; ?>
                                     </label>

--- a/admin/qtx_admin_settings.php
+++ b/admin/qtx_admin_settings.php
@@ -716,15 +716,14 @@ class QTX_Admin_Settings {
                 <th scope="row"><?php _e( 'Built-in Modules', 'qtranslate' ) ?></th>
                 <td>
                     <label for="qtranxs_modules"
-                           class="qtranxs_explanation"><?php _e( 'The built-in integration modules are automatically enabled if the related plugin is active and no incompatible plugin (e.g. legacy integration plugin) prevents them to be loaded.', 'qtranslate' ); ?></label>
+                           class="qtranxs_explanation"><?php _e( 'Each built-in integration module can only be enabled if the required plugin is active and no incompatible plugin (e.g. legacy integration plugin) prevents it to be loaded.', 'qtranslate' ); ?></label>
                     <br/>
                     <table id="qtranxs_modules" class="widefat">
                         <thead>
                         <tr>
-                            <th class="row-title"><?php _ex( 'Name', 'Modules table header', 'qtranslate' ); ?></th>
-                            <th><?php _ex( 'Plugin', 'Modules table header', 'qtranslate' ); ?></th>
-                            <th><?php _ex( 'Module', 'Modules table header', 'qtranslate' ); ?></th>
-                            <th><?php _ex( 'State', 'Modules table header', 'qtranslate' ); ?></th>
+                            <th class="row-title"><?php _ex( 'Name', 'Module admin', 'qtranslate' ); ?></th>
+                            <th><?php _ex( 'Required plugin', 'Module admin', 'qtranslate' ); ?></th>
+                            <th><?php _ex( 'Module', 'Module admin', 'qtranslate' ); ?></th>
                         </tr>
                         </thead>
                         <tbody>
@@ -736,19 +735,19 @@ class QTX_Admin_Settings {
                             ?>
                             <tr>
                                 <td>
-                                    <label for="admin_enabled_modules_<?php echo $module_id; ?>">
-                                    </label>
                                     <input type="checkbox"
                                            name="admin_enabled_modules[<?php echo $module_id; ?>]"
                                            id="admin_enabled_modules_<?php echo $module_id; ?>"
                                            value="1"<?php checked( $module_is_checked );
                                     disabled( $module_is_disabled ) ?>/>
-                                    <?php echo $module['def']['name']; ?>
+                                    <label for="admin_enabled_modules_<?php echo $module_id; ?>">
+                                        <?php echo $module['def']['name']; ?>
+                                    </label>
                                 </td>
                                 <td><?php echo $module['plugin'] ?></td>
-                                <td><?php echo $module['module'] ?></td>
                                 <td style="color: <?php echo $module['color'] ?>">
                                     <span class="dashicons <?php echo $module['icon'] ?>"></span>
+                                    <?php echo $module['module'] ?>
                                 </td>
                             </tr>
                         <?php endforeach; ?>

--- a/admin/qtx_admin_settings.php
+++ b/admin/qtx_admin_settings.php
@@ -731,16 +731,16 @@ class QTX_Admin_Settings {
                         <?php
                         foreach ( QTX_Admin_Modules::get_modules_infos() as $module ) :
                             $module_id = $module['def']['id'];
-                            $module_is_checked = ( isset( $q_config['modules_ma_enabled'][ $module_id ] ) && $q_config['modules_ma_enabled'][ $module_id ] ) || ( $module['status'] == QTX_MODULE_STATUS_ACTIVE );
+                            $module_is_checked = ( isset( $q_config['admin_enabled_modules'][ $module_id ] ) && $q_config['admin_enabled_modules'][ $module_id ] ) || ( $module['status'] == QTX_MODULE_STATUS_ACTIVE );
                             $module_is_disabled = ( QTX_Admin_Modules::can_module_be_activated( $module['def'] ) != QTX_MODULE_STATUS_ACTIVE );
                             ?>
                             <tr>
                                 <td>
-                                    <label for="modules_ma_enabled_<?php echo $module_id; ?>">
+                                    <label for="admin_enabled_modules_<?php echo $module_id; ?>">
                                     </label>
                                     <input type="checkbox"
-                                           name="modules_ma_enabled[<?php echo $module_id; ?>]"
-                                           id="modules_ma_enabled_<?php echo $module_id; ?>"
+                                           name="admin_enabled_modules[<?php echo $module_id; ?>]"
+                                           id="admin_enabled_modules_<?php echo $module_id; ?>"
                                            value="1"<?php checked( $module_is_checked );
                                     disabled( $module_is_disabled ) ?>/>
                                     <?php echo $module['def']['name']; ?>

--- a/modules/qtx_modules_handler.php
+++ b/modules/qtx_modules_handler.php
@@ -4,6 +4,7 @@ define( 'QTX_MODULE_STATUS_UNDEFINED', 0 );
 define( 'QTX_MODULE_STATUS_ACTIVE', 1 );
 define( 'QTX_MODULE_STATUS_INACTIVE', 2 );
 define( 'QTX_MODULE_STATUS_BLOCKED', 3 );
+define( 'QTX_MODULE_STATUS_DISABLED', 4 );
 
 class QTX_Modules_Handler {
     /**

--- a/modules/qtx_modules_handler.php
+++ b/modules/qtx_modules_handler.php
@@ -4,7 +4,6 @@ define( 'QTX_MODULE_STATUS_UNDEFINED', 0 );
 define( 'QTX_MODULE_STATUS_ACTIVE', 1 );
 define( 'QTX_MODULE_STATUS_INACTIVE', 2 );
 define( 'QTX_MODULE_STATUS_BLOCKED', 3 );
-define( 'QTX_MODULE_STATUS_DISABLED', 4 );
 
 class QTX_Modules_Handler {
     /**

--- a/modules/qtx_modules_handler.php
+++ b/modules/qtx_modules_handler.php
@@ -130,29 +130,4 @@ class QTX_Modules_Handler {
             )
         );
     }
-
-    public static function ma_modules_default_options() {
-        $module_defs = self::get_modules_defs();
-        // TODO: break deps on admin
-        require_once( QTRANSLATE_DIR . '/admin/qtx_admin_modules.php' );
-        $response = array();
-        foreach ( $module_defs as $module ) {
-            $response[ $module['id'] ] = $module['plugin'] === true ? false : QTX_Admin_Modules::check_module( $module ) === QTX_MODULE_STATUS_ACTIVE;
-        }
-
-        return $response;
-    }
-
-    public static function get_module_def_by_id( $module_id ) {
-        $module_defs = self::get_modules_defs();
-        $response    = array();
-        foreach ( $module_defs as $module ) {
-            if ( $module['id'] === $module_id ) {
-                $response = $module;
-                break;
-            }
-        }
-
-        return $response;
-    }
 }

--- a/modules/qtx_modules_handler.php
+++ b/modules/qtx_modules_handler.php
@@ -35,6 +35,19 @@ class QTX_Modules_Handler {
     }
 
     /**
+     * Check if a module is active.
+     *
+     * @param string $module_id
+     *
+     * @bool true if module active.
+     */
+    public static function is_module_active( $module_id ) {
+        $options_modules = get_option( 'qtranslate_modules', array() );
+
+        return isset( $options_modules[ $module_id ] ) && $options_modules[ $module_id ] === QTX_MODULE_STATUS_ACTIVE;
+    }
+
+    /**
      * Loads modules previously activated in the options after validation for plugin integration on admin-side.
      * Note these should be loaded before "qtranslate_init_language" is triggered.
      *

--- a/modules/qtx_modules_handler.php
+++ b/modules/qtx_modules_handler.php
@@ -1,20 +1,20 @@
 <?php
 
-define( 'QTX_MODULE_STATUS_UNDEFINED', 0 );
-define( 'QTX_MODULE_STATUS_ACTIVE', 1 );
-define( 'QTX_MODULE_STATUS_INACTIVE', 2 );
-define( 'QTX_MODULE_STATUS_BLOCKED', 3 );
+define( 'QTX_MODULE_STATE_UNDEFINED', 0 );
+define( 'QTX_MODULE_STATE_ACTIVE', 1 );
+define( 'QTX_MODULE_STATE_INACTIVE', 2 );
+define( 'QTX_MODULE_STATE_BLOCKED', 3 );
 
 class QTX_Modules_Handler {
     /**
      * Get the modules previously activated in the options after validation for plugin integration on admin-side.
      * Note these should be loaded before "qtranslate_init_language" is triggered.
      *
-     * @see QTX_Admin_Modules::update_modules_status()
+     * @see QTX_Admin_Modules::update_modules_state()
      * @array Module defs.
      */
     public static function get_active_modules() {
-        $options_modules = get_option( 'qtranslate_modules', array() );
+        $options_modules = get_option( 'qtranslate_modules_state', array() );
         if ( ! is_array( $options_modules ) ) {
             return array();
         }
@@ -25,8 +25,8 @@ class QTX_Modules_Handler {
             if ( ! array_key_exists( $def_module['id'], $options_modules ) ) {
                 continue;
             }
-            $module_status = $options_modules[ $def_module['id'] ];
-            if ( $module_status === QTX_MODULE_STATUS_ACTIVE ) {
+            $state = $options_modules[ $def_module['id'] ];
+            if ( $state === QTX_MODULE_STATE_ACTIVE ) {
                 array_push( $active_modules, $def_module );
             }
         }
@@ -42,16 +42,16 @@ class QTX_Modules_Handler {
      * @bool true if module active.
      */
     public static function is_module_active( $module_id ) {
-        $options_modules = get_option( 'qtranslate_modules', array() );
+        $options_modules = get_option( 'qtranslate_modules_state', array() );
 
-        return isset( $options_modules[ $module_id ] ) && $options_modules[ $module_id ] === QTX_MODULE_STATUS_ACTIVE;
+        return isset( $options_modules[ $module_id ] ) && $options_modules[ $module_id ] === QTX_MODULE_STATE_ACTIVE;
     }
 
     /**
      * Loads modules previously activated in the options after validation for plugin integration on admin-side.
      * Note these should be loaded before "qtranslate_init_language" is triggered.
      *
-     * @see QTX_Admin_Modules::update_modules_status()
+     * @see QTX_Admin_Modules::update_modules_state()
      */
     public static function load_active_modules() {
         $def_modules = self::get_active_modules();

--- a/modules/slugs/includes/class-qtranslate-slug.php
+++ b/modules/slugs/includes/class-qtranslate-slug.php
@@ -32,8 +32,8 @@ class QtranslateSlug {
      * Initialise the Class with all hooks.
      */
     function init() {
-        global $q_config;
-        if ( ! $q_config['ma_module_enabled']['slugs'] ) {
+        // TODO: remove `plugins_loaded` hook to initialize the module, it is loaded by QTX handler not WordPress.
+        if ( ! QTX_Modules_Handler::is_module_active( 'slugs' ) ) {
             return;
         }
 

--- a/modules/slugs/includes/qtranslate-slug-admin.php
+++ b/modules/slugs/includes/qtranslate-slug-admin.php
@@ -26,7 +26,7 @@ register_deactivation_hook( QTRANSLATE_FILE, 'qts_deactivate' );
 register_uninstall_hook( QTRANSLATE_FILE, 'qts_uninstall' );
 
 /**
- * Adds support for qtranslate in taxonomies.
+ * Add support for taxonomies and optional integration with WooCommerce.
  */
 function qts_taxonomies_hooks() {
     global $qtranslate_slug;
@@ -40,6 +40,10 @@ function qts_taxonomies_hooks() {
             add_filter( 'manage_edit-' . $taxonomy->name . '_columns', 'qts_taxonomy_columns' );
             add_filter( 'manage_' . $taxonomy->name . '_custom_column', 'qts_taxonomy_custom_column', 0, 3 );
         }
+    }
+
+    if ( QTX_Modules_Handler::is_module_active( 'woo-commerce' ) ) {
+        add_action( 'woocommerce_after_add_attribute_fields', 'qts_show_add_term_fields' );
     }
 }
 
@@ -427,6 +431,16 @@ function qts_hide_term_slug_box() {
         case 'term.php':
             $id = 'slug';
             break;
+        case 'edit.php':
+            // Handle WooCommerce edit product attributes page.
+            if ( isset( $_GET['page'] ) && $_GET['page'] == 'product_attributes' ) {
+                $id = 'attribute_name';
+                // TODO: actual slug column to be added (javascript seems the only way currently). For the time being, possibly overridden slugs column is hidden.
+                $additional_jquery =
+                    "$('table tr th:nth-child(2)').hide()" . PHP_EOL .
+                    "$('table tr td:nth-child(2)').hide()" . PHP_EOL;
+            }
+            break;
         default:
             return;
     endswitch;
@@ -436,6 +450,9 @@ function qts_hide_term_slug_box() {
     echo "  jQuery(document).ready(function($){" . PHP_EOL;
     echo "      $(\"#" . $id . "\").parent().hide();" . PHP_EOL;
     echo "      $(\".form-field td #slug\").parent().parent().hide();" . PHP_EOL;
+    if ( isset( $additional_jquery ) ) {
+        echo $additional_jquery;
+    }
     echo "  });" . PHP_EOL;
     echo "</script>" . PHP_EOL;
 }

--- a/modules/slugs/includes/qtranslate-slug-admin.php
+++ b/modules/slugs/includes/qtranslate-slug-admin.php
@@ -563,10 +563,10 @@ function qts_get_terms( $terms, $taxonomy ) {
 }
 
 function qts_ma_module_updated() {
-    global $q_config;
-    if ( $q_config['ma_module_enabled']['slugs'] ) {
+    if ( QTX_Modules_Handler::is_module_active( 'slugs' ) ) {
         qts_multi_activate();
     } else {
         qts_deactivate();
+
     }
 }

--- a/qtranslate_core.php
+++ b/qtranslate_core.php
@@ -779,7 +779,7 @@ function qtranxf_load_config() {
     foreach ( $qtranslate_options['front']['array'] as $name => $def ) {
         qtranxf_load_option_array( $name, $def );
     }
-    // qtranxf_load_option_array( 'ma_module_enabled', array() );
+
     qtranxf_load_option_array( 'term_name', array() );
 
     if ( $q_config['filter_options_mode'] == QTX_FILTER_OPTIONS_LIST ) {

--- a/qtranslate_core.php
+++ b/qtranslate_core.php
@@ -779,7 +779,7 @@ function qtranxf_load_config() {
     foreach ( $qtranslate_options['front']['array'] as $name => $def ) {
         qtranxf_load_option_array( $name, $def );
     }
-    qtranxf_load_option_array( 'ma_module_enabled', $qtranslate_options['default_value']['ma_module_enabled'] );
+    // qtranxf_load_option_array( 'ma_module_enabled', array() );
     qtranxf_load_option_array( 'term_name', array() );
 
     if ( $q_config['filter_options_mode'] == QTX_FILTER_OPTIONS_LIST ) {

--- a/qtranslate_options.php
+++ b/qtranslate_options.php
@@ -114,7 +114,6 @@ function qtranxf_set_default_options( &$ops ) {
         'filter_options'         => QTX_FILTER_OPTIONS_DEFAULT, // array
         'ignore_file_types'      => QTX_IGNORE_FILE_TYPES,  // array
         'domains'                => null,   // array
-        'ma_module_enabled'      => QTX_Modules_Handler::ma_modules_default_options(),
     );
 
     // must have function 'qtranxf_default_option_name()' which returns a default value for option 'option_name'.


### PR DESCRIPTION
Disambiguate the confusion between module state and admin options.
* The module state usually depends on other plugin states.
* The admin settings to manually disable or enable the modules are
just admin "preferences" for the module activations.

Changes
* Admin settings (checkboxes)
Make this option admin (previously core) as it's not used on front side.
Rename the `ma_module_enabled` option to `admin_enabled_modules`.
It is saved only from the admin settings and can be deleted at any time.
Make the list display clearer.

* Module state
Rename module _status_ to _state_.
Refactor the module state update to be triggered on various events.
Rename `qtranslate_modules` option to `qtranslate_modules_state`.
The admin enabled settings are only read for the state updates.