### PR TITLE
Integrate ACF settings in modules tab

### DIFF
--- a/modules/qtx_admin_module.php
+++ b/modules/qtx_admin_module.php
@@ -80,6 +80,7 @@ class QTX_Admin_Module {
                 'name'         => 'ACF',
                 'plugins'      => [ 'advanced-custom-fields/acf.php', 'advanced-custom-fields-pro/acf.php' ],
                 'incompatible' => 'acf-qtranslate/acf-qtranslate.php',
+                'has_settings' => true,
             ],
             [
                 'id'           => 'all-in-one-seo-pack',


### PR DESCRIPTION
Preserve most of the settings API usage in a new module tab.
The option name remains unchanged as `acf_qtranslate`, may evolve.