### PR TITLE
QTS: fix to handle esc_sql() 4.8.3 breaking change

### DIFF
--- a/modules/slugs/includes/class-qtranslate-slug.php
+++ b/modules/slugs/includes/class-qtranslate-slug.php
@@ -957,7 +957,7 @@ class QtranslateSlug {
         $page_path     = str_replace( '%20', ' ', $page_path );
         $parts         = explode( '/', trim( $page_path, '/' ) );
         $parts         = array_map( 'esc_sql', $parts );
-        $parts         = array_map(array($wpdb,'remove_placeholder_escape'), $parts);
+        $parts         = array_map( array( $wpdb, 'remove_placeholder_escape' ), $parts );
         $parts         = array_map( 'sanitize_title_for_query', $parts );
         $in_string     = "'" . implode( "','", $parts ) . "'";
         $meta_key      = QTS_META_PREFIX . $this->get_temp_lang();

--- a/modules/slugs/includes/class-qtranslate-slug.php
+++ b/modules/slugs/includes/class-qtranslate-slug.php
@@ -956,9 +956,16 @@ class QtranslateSlug {
         $page_path     = str_replace( '%2F', '/', $page_path );
         $page_path     = str_replace( '%20', ' ', $page_path );
         $parts         = explode( '/', trim( $page_path, '/' ) );
-        $parts         = array_map( 'esc_sql', $parts );
-        $parts         = array_map( array( $wpdb, 'remove_placeholder_escape' ), $parts );
-        $parts         = array_map( 'sanitize_title_for_query', $parts );
+        $parts         = array_map(
+                            function ( $a ) {
+                                global $wpdb;
+                                return sanitize_title_for_query(
+                                    $wpdb->remove_placeholder_escape(
+                                        esc_sql( $a )
+                                    )
+                                );
+                            },
+                            $parts );
         $in_string     = "'" . implode( "','", $parts ) . "'";
         $meta_key      = QTS_META_PREFIX . $this->get_temp_lang();
         $post_type_sql = $post_type;

--- a/modules/slugs/includes/class-qtranslate-slug.php
+++ b/modules/slugs/includes/class-qtranslate-slug.php
@@ -957,6 +957,7 @@ class QtranslateSlug {
         $page_path     = str_replace( '%20', ' ', $page_path );
         $parts         = explode( '/', trim( $page_path, '/' ) );
         $parts         = array_map( 'esc_sql', $parts );
+        $parts         = array_map(array($wpdb,'remove_placeholder_escape'), $parts);
         $parts         = array_map( 'sanitize_title_for_query', $parts );
         $in_string     = "'" . implode( "','", $parts ) . "'";
         $meta_key      = QTS_META_PREFIX . $this->get_temp_lang();


### PR DESCRIPTION
Since 4.8.3, ‘%’ characters will be replaced with a placeholder string with esc_sql().
This fix replaces back the placeholder to ‘%’ after esc_sql() call to retain the original behaviour.