### PR TITLE
Harmonize module options

### DIFF
--- a/admin/qtx_activation_hook.php
+++ b/admin/qtx_activation_hook.php
@@ -753,7 +753,6 @@ function qtranxf_clear_debug_log() {
     }
 }
 
-
 function qtranxf_activation_hook() {
     qtranxf_clear_debug_log();
     if ( version_compare( PHP_VERSION, '5.4' ) < 0 ) {
@@ -784,6 +783,11 @@ function qtranxf_activation_hook() {
     if ( is_plugin_active( 'qtranslate-x/qtranslate.php' ) ) {
         qtranxf_admin_notice_deactivate_plugin( 'qTranslate-X', 'qtranslate-x/qtranslate.php' );
     }
+
+    // Migrate legacy options, temporary transitions during evolutions.
+    qtranxf_migrate_legacy_option( 'qtranslate_modules', QTX_OPTIONS_MODULES_STATE );
+    qtranxf_migrate_legacy_option( 'acf_qtranslate', QTX_OPTIONS_MODULE_ACF, false );
+    qtranxf_migrate_legacy_option( 'qts_options', QTX_OPTIONS_MODULE_SLUGS, false );
 
     $ts                     = time();
     $next_thanks            = get_option( 'qtranslate_next_thanks' );

--- a/admin/qtx_activation_hook.php
+++ b/admin/qtx_activation_hook.php
@@ -784,10 +784,10 @@ function qtranxf_activation_hook() {
         qtranxf_admin_notice_deactivate_plugin( 'qTranslate-X', 'qtranslate-x/qtranslate.php' );
     }
 
-    // Migrate legacy options, temporary transitions during evolutions.
-    qtranxf_migrate_legacy_option( 'qtranslate_modules', QTX_OPTIONS_MODULES_STATE );
-    qtranxf_migrate_legacy_option( 'acf_qtranslate', QTX_OPTIONS_MODULE_ACF, false );
-    qtranxf_migrate_legacy_option( 'qts_options', QTX_OPTIONS_MODULE_SLUGS, false );
+    // Migrate (rename/import) legacy options, temporary transitions during evolutions.
+    qtranxf_rename_legacy_option( 'qtranslate_modules', QTX_OPTIONS_MODULES_STATE );
+    qtranxf_import_legacy_option( 'acf_qtranslate', QTX_OPTIONS_MODULE_ACF, false );
+    qtranxf_import_legacy_option( 'qts_options', QTX_OPTIONS_MODULE_SLUGS, false );
 
     $ts                     = time();
     $next_thanks            = get_option( 'qtranslate_next_thanks' );

--- a/admin/qtx_admin_options.php
+++ b/admin/qtx_admin_options.php
@@ -91,3 +91,28 @@ function qtranxf_admin_load_config() {
 
     qtranxf_add_conf_filters();
 }
+
+/**
+ * Migrate, rename and clean up a legacy option.
+ *
+ * Recopy the legacy option if the new doesn't already exist.
+ * Delete the legacy option if belonging to `qtranslate`, preserve external plugin options.
+ *
+ * @param string $old_name
+ * @param string $new_name
+ * @param bool|string $autoload as in update_option
+ *
+ * @return void
+ */
+function qtranxf_migrate_legacy_option( $old_name, $new_name, $autoload = null ) {
+    if ( ! get_option( $new_name ) ) {
+        $old_value = get_option( $old_name );
+        if ( $old_value ) {
+            update_option( $new_name, $old_value, $autoload );
+        }
+    }
+    // Clean up legacy options in any case, but only for own plugin.
+    if ( strpos( $old_name, 'qtranslate_' ) === 0 ) {
+        delete_option( $old_name );
+    }
+}

--- a/admin/qtx_admin_options.php
+++ b/admin/qtx_admin_options.php
@@ -93,10 +93,7 @@ function qtranxf_admin_load_config() {
 }
 
 /**
- * Migrate, rename and clean up a legacy option.
- *
- * Recopy the legacy option if the new doesn't already exist.
- * Delete the legacy option if belonging to `qtranslate`, preserve external plugin options.
+ * Import legacy option by recopying its value if the new option doesn't already exist.
  *
  * @param string $old_name
  * @param string $new_name
@@ -104,15 +101,29 @@ function qtranxf_admin_load_config() {
  *
  * @return void
  */
-function qtranxf_migrate_legacy_option( $old_name, $new_name, $autoload = null ) {
+function qtranxf_import_legacy_option( $old_name, $new_name, $autoload = null ) {
+    assert( strpos( $new_name, 'qtranslate_' ) === 0 );
     if ( ! get_option( $new_name ) ) {
         $old_value = get_option( $old_name );
         if ( $old_value ) {
             update_option( $new_name, $old_value, $autoload );
         }
     }
-    // Clean up legacy options in any case, but only for own plugin.
-    if ( strpos( $old_name, 'qtranslate_' ) === 0 ) {
-        delete_option( $old_name );
-    }
+}
+
+/**
+ * Rename a legacy option: import and cleanup.
+ * Only applies to `qtranslate` options, preserve external plugin options.
+ *
+ * @param string $old_name
+ * @param string $new_name
+ * @param bool|string $autoload as in update_option
+ *
+ * @return void
+ */
+function qtranxf_rename_legacy_option( $old_name, $new_name, $autoload = null ) {
+    assert( strpos( $new_name, 'qtranslate_' ) === 0 );
+    assert( strpos( $old_name, 'qtranslate_' ) === 0 );
+    qtranxf_import_legacy_option( $old_name, $new_name, $autoload );
+    delete_option( $old_name );
 }

--- a/admin/qtx_admin_options_update.php
+++ b/admin/qtx_admin_options_update.php
@@ -360,7 +360,9 @@ function qtranxf_reset_config() {
     // internal private options not loaded by default
     delete_option( 'qtranslate_next_update_mo' );
     delete_option( 'qtranslate_next_thanks' );
-    delete_option( 'qtranslate_modules_state' );
+    delete_option( QTX_OPTIONS_MODULES_STATE );
+    delete_option( QTX_OPTIONS_MODULE_ACF );
+    delete_option( QTX_OPTIONS_MODULE_SLUGS );
 
     // obsolete options
     delete_option( 'qtranslate_custom_pages' );

--- a/modules/acf/src/plugin.php
+++ b/modules/acf/src/plugin.php
@@ -32,6 +32,10 @@ class acf_qtranslate_plugin {
     public function init() {
         static $plugin_loaded = false;
         if ( ! $plugin_loaded && $this->acf_enabled() ) {
+            // TODO: remove temporary rename of legacy option for master, rely on plugin activation in next release.
+            require_once( QTRANSLATE_DIR . '/admin/qtx_admin_options.php' );
+            qtranxf_migrate_legacy_option( 'acf_qtranslate', QTX_OPTIONS_MODULE_ACF, false );
+
             if ( $this->acf_major_version() === 5 ) {
                 require_once ACF_QTRANSLATE_PLUGIN_DIR . 'src/acf_5/acf.php';
                 $this->acf = new acf_qtranslate_acf_5( $this );
@@ -230,7 +234,7 @@ class acf_qtranslate_plugin {
      * @return mixed
      */
     function get_plugin_setting( $name, $default = null ) {
-        $options = get_option( 'acf_qtranslate' );
+        $options = get_option( QTX_OPTIONS_MODULE_ACF );
         if ( isset( $options[ $name ] ) ) {
             return $options[ $name ];
         }
@@ -242,7 +246,7 @@ class acf_qtranslate_plugin {
      * Register settings and default fields
      */
     function admin_init() {
-        register_setting( 'settings-qtranslate-acf', 'acf_qtranslate' );
+        register_setting( 'settings-qtranslate-acf', QTX_OPTIONS_MODULE_ACF );
 
         // Define a placeholder for the fields without title or content.
         add_settings_section(
@@ -289,8 +293,8 @@ class acf_qtranslate_plugin {
         if ( ! isset( $_POST['nonce_acf'] ) || ! wp_verify_nonce( $_POST['nonce_acf'], 'acf' ) ) {
             return;
         }
-        $options = isset( $_POST['acf_qtranslate'] ) ? $_POST['acf_qtranslate'] : null;
-        update_option( 'acf_qtranslate', $options );
+        $options = isset( $_POST[ QTX_OPTIONS_MODULE_ACF ] ) ? $_POST[ QTX_OPTIONS_MODULE_ACF ] : null;
+        update_option( QTX_OPTIONS_MODULE_ACF, $options, false );
     }
 
     /**
@@ -299,7 +303,7 @@ class acf_qtranslate_plugin {
     function render_setting_translate_standard_field_types() {
         ?>
         <input type="checkbox"
-               name="acf_qtranslate[translate_standard_field_types]" <?php checked( $this->get_plugin_setting( 'translate_standard_field_types' ), 1 ); ?>
+               name="<?php echo QTX_OPTIONS_MODULE_ACF ?>[translate_standard_field_types]" <?php checked( $this->get_plugin_setting( 'translate_standard_field_types' ), 1 ); ?>
                value="1">
         <?php
     }
@@ -310,7 +314,7 @@ class acf_qtranslate_plugin {
     function render_setting_show_language_tabs() {
         ?>
         <input type="checkbox"
-               name="acf_qtranslate[show_language_tabs]" <?php checked( $this->get_plugin_setting( 'show_language_tabs' ), 1 ); ?>
+               name="<?php echo QTX_OPTIONS_MODULE_ACF ?>[show_language_tabs]" <?php checked( $this->get_plugin_setting( 'show_language_tabs' ), 1 ); ?>
                value="1">
         <?php
     }
@@ -320,7 +324,8 @@ class acf_qtranslate_plugin {
      */
     function render_setting_show_on_pages() {
         ?>
-        <textarea name="acf_qtranslate[show_on_pages]" style="max-width:500px;width:100%;height:200px;padding-top:6px"
+        <textarea name="<?php echo QTX_OPTIONS_MODULE_ACF ?>[show_on_pages]"
+                  style="max-width:500px;width:100%;height:200px;padding-top:6px"
                   placeholder="post.php"><?= esc_html( $this->get_plugin_setting( 'show_on_pages' ) ) ?></textarea><br>
         <small>Enter each page on it's own line</small>
         <?php

--- a/modules/acf/src/plugin.php
+++ b/modules/acf/src/plugin.php
@@ -32,9 +32,9 @@ class acf_qtranslate_plugin {
     public function init() {
         static $plugin_loaded = false;
         if ( ! $plugin_loaded && $this->acf_enabled() ) {
-            // TODO: remove temporary rename of legacy option for master, rely on plugin activation in next release.
+            // TODO: remove temporary import of legacy option for master, rely on plugin activation in next release.
             require_once( QTRANSLATE_DIR . '/admin/qtx_admin_options.php' );
-            qtranxf_migrate_legacy_option( 'acf_qtranslate', QTX_OPTIONS_MODULE_ACF, false );
+            qtranxf_import_legacy_option( 'acf_qtranslate', QTX_OPTIONS_MODULE_ACF, false );
 
             if ( $this->acf_major_version() === 5 ) {
                 require_once ACF_QTRANSLATE_PLUGIN_DIR . 'src/acf_5/acf.php';

--- a/modules/qtx_admin_module_manager.php
+++ b/modules/qtx_admin_module_manager.php
@@ -24,7 +24,7 @@ class QTX_Admin_Module_Manager {
      * AND
      * - if the `admin_enabled_modules` admin option is checked for that module.
      *
-     * Update the 'qtranslate_modules_state' option, telling which module should be loaded.
+     * Update the QTX_OPTIONS_MODULES_STATE option, telling which module should be loaded.
      * Note each module can enable hooks both for admin and front requests.
      *
      * @param callable $func_is_active callback to evaluate if a plugin is active
@@ -45,8 +45,8 @@ class QTX_Admin_Module_Manager {
             $option_modules[ $module->id ] = $state;
         }
 
-        $old_option_modules = get_option( 'qtranslate_modules_state' );
-        update_option( 'qtranslate_modules_state', $option_modules );
+        $old_option_modules = get_option( QTX_OPTIONS_MODULES_STATE );
+        update_option( QTX_OPTIONS_MODULES_STATE, $option_modules );
 
         // Trigger info notices and potential loading only if changed.
         if ( $old_option_modules != $option_modules ) {
@@ -132,7 +132,7 @@ class QTX_Admin_Module_Manager {
     }
 
     public static function admin_notices() {
-        $options_modules = get_option( 'qtranslate_modules_state', array() );
+        $options_modules = get_option( QTX_OPTIONS_MODULES_STATE, array() );
         if ( empty( $options_modules ) ) {
             $msg   = '<p>' . sprintf( __( 'Modules state undefined in %s. Please deactivate it and reactivate it again from the plugins page.', 'qtranslate' ), 'qTranslate&#8209;XT' ) . '</p>';
             $nonce = wp_create_nonce( 'deactivate-plugin_qtranslate-xt/qtranslate.php' );

--- a/modules/qtx_admin_module_settings.php
+++ b/modules/qtx_admin_module_settings.php
@@ -107,7 +107,7 @@ class QTX_Admin_Module_Settings {
      * @return QTX_Admin_Module_Settings[]
      */
     public static function get_settings_modules() {
-        $states   = get_option( 'qtranslate_modules_state', array() );
+        $states   = get_option( QTX_OPTIONS_MODULES_STATE, array() );
         $settings = array();
         foreach ( QTX_Admin_Module::get_modules() as $module ) {
             $state      = isset( $states[ $module->id ] ) ? $states[ $module->id ] : QTX_MODULE_STATE_UNDEFINED;

--- a/modules/qtx_module_loader.php
+++ b/modules/qtx_module_loader.php
@@ -16,7 +16,7 @@ class QTX_Module_Loader {
      * @bool true if module active.
      */
     public static function is_module_active( $module_id ) {
-        $modules_state = get_option( 'qtranslate_modules_state', array() );
+        $modules_state = get_option( QTX_OPTIONS_MODULES_STATE, array() );
 
         return isset( $modules_state[ $module_id ] ) && $modules_state[ $module_id ] === QTX_MODULE_STATE_ACTIVE;
     }
@@ -31,7 +31,7 @@ class QTX_Module_Loader {
      * Note also the modules should be loaded before "qtranslate_init_language" is triggered.
      */
     public static function load_active_modules() {
-        $modules_state = get_option( 'qtranslate_modules_state', array() );
+        $modules_state = get_option( QTX_OPTIONS_MODULES_STATE, array() );
 
         foreach ( $modules_state as $module_id => $state ) {
             if ( $state === QTX_MODULE_STATE_ACTIVE ) {

--- a/modules/slugs/includes/class-qtranslate-slug.php
+++ b/modules/slugs/includes/class-qtranslate-slug.php
@@ -37,6 +37,10 @@ class QtranslateSlug {
             return;
         }
 
+        // TODO: remove temporary import of legacy option for master, rely on plugin activation in next release.
+        require_once( QTRANSLATE_DIR . '/admin/qtx_admin_options.php' );
+        qtranxf_import_legacy_option( 'qts_options', QTX_OPTIONS_MODULE_SLUGS, false );
+
         $this->options_buffer      = get_option( QTX_OPTIONS_MODULE_SLUGS, array() );
         $this->permalink_structure = get_option( 'permalink_structure' );
 

--- a/modules/slugs/includes/class-qtranslate-slug.php
+++ b/modules/slugs/includes/class-qtranslate-slug.php
@@ -37,7 +37,7 @@ class QtranslateSlug {
             return;
         }
 
-        $this->options_buffer      = get_option( QTS_OPTIONS_NAME, array() );
+        $this->options_buffer      = get_option( QTX_OPTIONS_MODULE_SLUGS, array() );
         $this->permalink_structure = get_option( 'permalink_structure' );
 
         if ( ! is_admin() ) {

--- a/modules/slugs/includes/qtranslate-slug-admin.php
+++ b/modules/slugs/includes/qtranslate-slug-admin.php
@@ -72,7 +72,7 @@ function qts_multi_activate() {
 function qts_uninstall() {
     global $q_config, $wpdb;
 
-    delete_option( QTS_OPTIONS_NAME );
+    delete_option( QTX_OPTIONS_MODULE_SLUGS );
 
     $meta_keys = array();
     foreach ( $q_config['enabled_languages'] as $lang ) {

--- a/modules/slugs/includes/qtranslate-slug-settings.php
+++ b/modules/slugs/includes/qtranslate-slug-settings.php
@@ -48,7 +48,7 @@ function qts_show_form_field( $args = array() ) {
     $choices = $args['choices'];
     $class   = $args['class'];
 
-    $options = $qtranslate_slug->options_buffer ? $qtranslate_slug->options_buffer : get_option( QTS_OPTIONS_NAME, array() );
+    $options = $qtranslate_slug->options_buffer ? $qtranslate_slug->options_buffer : get_option( QTX_OPTIONS_MODULE_SLUGS, array() );
 
     // pass the standard value if the option is not yet set in the database
     if ( ! isset( $options[ $id ] ) && $type != 'checkbox' ) {
@@ -67,7 +67,7 @@ function qts_show_form_field( $args = array() ) {
         case 'text':
             $options[ $id ] = stripslashes( $options[ $id ] );
             $options[ $id ] = esc_attr( $options[ $id ] );
-            echo "<input class='regular-text$field_class' type='text' id='$id' name='" . QTS_OPTIONS_NAME . "[$id]' value='$options[$id]' />";
+            echo "<input class='regular-text$field_class' type='text' id='$id' name='" . QTX_OPTIONS_MODULE_SLUGS . "[$id]' value='$options[$id]' />";
             echo ( $desc != '' ) ? "<br /><p class='qtranxs-notes'>$desc</p>" : "";
             break;
 
@@ -85,8 +85,8 @@ function qts_show_form_field( $args = array() ) {
                 } else {
                     $value = '';
                 }
-                echo "<label for=" . QTS_OPTIONS_NAME . "[$id|${item[1]}]>" . $item[0] . "</label> " .
-                     "<input class='$field_class' type='text' id='$id|${item[1]}' name='" . QTS_OPTIONS_NAME . "[$id|${item[1]}]' value='" . urldecode( $value ) . "' /><br/>";
+                echo "<label for=" . QTX_OPTIONS_MODULE_SLUGS . "[$id|${item[1]}]>" . $item[0] . "</label> " .
+                     "<input class='$field_class' type='text' id='$id|${item[1]}' name='" . QTX_OPTIONS_MODULE_SLUGS . "[$id|${item[1]}]' value='" . urldecode( $value ) . "' /><br/>";
             }
             echo ( $desc != '' ) ? "<p class='qtranxs-notes'>$desc</p>" : "";
             break;
@@ -94,12 +94,12 @@ function qts_show_form_field( $args = array() ) {
         case 'textarea':
             $options[ $id ] = stripslashes( $options[ $id ] );
             $options[ $id ] = esc_html( $options[ $id ] );
-            echo "<textarea class='textarea$field_class' type='text' id='$id' name='" . QTS_OPTIONS_NAME . "[$id]' rows='5' cols='30'>$options[$id]</textarea>";
+            echo "<textarea class='textarea$field_class' type='text' id='$id' name='" . QTX_OPTIONS_MODULE_SLUGS . "[$id]' rows='5' cols='30'>$options[$id]</textarea>";
             echo ( $desc != '' ) ? "<br /><p class='qtranxs-notes'>$desc</p>" : "";
             break;
 
         case 'select':
-            echo "<select id='$id' class='select$field_class' name='" . QTS_OPTIONS_NAME . "[$id]'>";
+            echo "<select id='$id' class='select$field_class' name='" . QTX_OPTIONS_MODULE_SLUGS . "[$id]'>";
             foreach ( $choices as $item ) {
                 $value = esc_attr( $item );
                 $item  = esc_html( $item );
@@ -112,7 +112,7 @@ function qts_show_form_field( $args = array() ) {
             break;
 
         case 'select2':
-            echo "<select id='$id' class='select$field_class' name='" . QTS_OPTIONS_NAME . "[$id]'>";
+            echo "<select id='$id' class='select$field_class' name='" . QTX_OPTIONS_MODULE_SLUGS . "[$id]'>";
             foreach ( $choices as $item ) {
 
                 $item    = explode( "|", $item );
@@ -126,7 +126,7 @@ function qts_show_form_field( $args = array() ) {
             break;
 
         case 'checkbox':
-            echo "<input class='checkbox$field_class' type='checkbox' id='$id' name='" . QTS_OPTIONS_NAME . "[$id]' value='1' " . checked( $options[ $id ], 1, false ) . " />";
+            echo "<input class='checkbox$field_class' type='checkbox' id='$id' name='" . QTX_OPTIONS_MODULE_SLUGS . "[$id]' value='1' " . checked( $options[ $id ], 1, false ) . " />";
             echo ( $desc != '' ) ? "<br /><p class='qtranxs-notes'>$desc</p>" : "";
             break;
 
@@ -144,7 +144,7 @@ function qts_show_form_field( $args = array() ) {
                     }
                 }
 
-                echo "<input class='checkbox$field_class' type='checkbox' id='$id|$item[1]' name='" . QTS_OPTIONS_NAME . "[$id|$item[1]]' value='1' $checked /> $item[0] <br/>";
+                echo "<input class='checkbox$field_class' type='checkbox' id='$id|$item[1]' name='" . QTX_OPTIONS_MODULE_SLUGS . "[$id|$item[1]]' value='1' $checked /> $item[0] <br/>";
             }
             echo ( $desc != '' ) ? "<br /><p class='qtranxs-notes'>$desc</p>" : "";
             break;
@@ -162,7 +162,7 @@ function qts_show_form_field( $args = array() ) {
                     $checked = 'checked="checked"';
                 }
 
-                echo "<label for='$id|$item_value'><input class='radio$field_class' type='radio' id='$id|$item_value' name='" . QTS_OPTIONS_NAME . "[$id]' value='$item_value' $checked /> <strong>$item_key</strong>";
+                echo "<label for='$id|$item_value'><input class='radio$field_class' type='radio' id='$id|$item_value' name='" . QTX_OPTIONS_MODULE_SLUGS . "[$id]' value='$item_value' $checked /> <strong>$item_key</strong>";
                 if ( isset( $desc[ $index ] ) && ! empty( $desc[ $index ] ) ) {
                     echo ": " . $desc[ $index ];
                 }
@@ -347,8 +347,8 @@ function qts_validate_options( $input ) {
 function qts_update_settings() {
     global $qtranslate_slug;
     $qts_settings = false;
-    if ( isset( $_POST[ QTS_OPTIONS_NAME ] ) ) {
-        $qts_settings = qts_validate_options( $_POST[ QTS_OPTIONS_NAME ] );
+    if ( isset( $_POST[ QTX_OPTIONS_MODULE_SLUGS ] ) ) {
+        $qts_settings = qts_validate_options( $_POST[ QTX_OPTIONS_MODULE_SLUGS ] );
     }
 
     if ( ! $qts_settings || empty( $qts_settings ) ) {
@@ -357,7 +357,7 @@ function qts_update_settings() {
     if ( $qtranslate_slug->options_buffer == $qts_settings ) {
         return;
     }
-    update_option( QTS_OPTIONS_NAME, $qts_settings );
+    update_option( QTX_OPTIONS_MODULE_SLUGS, $qts_settings, false );
     $qtranslate_slug->options_buffer = $qts_settings;
     flush_rewrite_rules();
 }

--- a/modules/slugs/slugs.php
+++ b/modules/slugs/slugs.php
@@ -3,12 +3,13 @@
 if ( ! defined( "QTS_PREFIX" ) ) {
     define( "QTS_PREFIX", '_qts_' );
 }
-if ( ! defined( "QTS_OPTIONS_NAME" ) ) {
-    define( "QTS_OPTIONS_NAME", 'qts_options' );
-}
 if ( ! defined( "QTS_META_PREFIX" ) ) {
     define( "QTS_META_PREFIX", QTS_PREFIX . 'slug_' );
 }
+
+// TODO: remove temporary rename of legacy option for master, rely on plugin activation in next release.
+require_once( QTRANSLATE_DIR . '/admin/qtx_admin_options.php' );
+qtranxf_migrate_legacy_option( 'qts_options', QTX_OPTIONS_MODULE_SLUGS, false );
 
 // Init the module
 

--- a/modules/slugs/slugs.php
+++ b/modules/slugs/slugs.php
@@ -7,10 +7,6 @@ if ( ! defined( "QTS_META_PREFIX" ) ) {
     define( "QTS_META_PREFIX", QTS_PREFIX . 'slug_' );
 }
 
-// TODO: remove temporary rename of legacy option for master, rely on plugin activation in next release.
-require_once( QTRANSLATE_DIR . '/admin/qtx_admin_options.php' );
-qtranxf_migrate_legacy_option( 'qts_options', QTX_OPTIONS_MODULE_SLUGS, false );
-
 // Init the module
 
 include_once( dirname( __FILE__ ) . '/includes/class-qtranslate-slug.php' );

--- a/qtranslate_options.php
+++ b/qtranslate_options.php
@@ -55,10 +55,22 @@ define( 'QTX_IGNORE_FILE_TYPES', 'gif,jpg,jpeg,png,svg,pdf,swf,tif,rar,zip,7z,mp
 // Language code format: ISO 639-1 (2 alpha), 639-2 or 639-3 (3 alpha)
 define( 'QTX_LANG_CODE_FORMAT', '[a-z]{2,3}' );
 
+/**
+ * Option names.
+ */
+const QTX_OPTIONS_MODULES_STATE = 'qtranslate_modules_state';
+const QTX_OPTIONS_MODULE_ACF    = 'qtranslate_module_acf';
+const QTX_OPTIONS_MODULE_SLUGS  = 'qtranslate_module_slugs';
 
+/**
+ * @global array Global configuration, interpreted from settings and i18n configuration loaded from JSON.
+ */
 global $q_config;
-global $qtranslate_options;
 
+/**
+ * @global array Global options, mapped at a lower level to the settings.
+ */
+global $qtranslate_options;
 
 /**
  * array of default option values


### PR DESCRIPTION
The module custom options are difficult to track due to legacy names.
Make all the name consistent by renaming the old options:
- `acf_qtranslate` -> `qtranslate_module_acf`
- `qts_options` -> `qtranslate_module_slugs`
- `qtranslate_modules` -> `qtranslate_modules_state`
  (already pre-renamed in #1150)

Generalize migration and cleanup on plugin activation:
- legacy options belonging to external plugins are preserved and imported
- internal options are renamed from legacy + cleanup.

Create new constants to better keep track the names (e.g. ACF forms) and deletion.
New custom options for modules are updated with `autoload=false`.
Add temporary import for `master`, to be removed before release.