### PR TITLE
QTS: fix query var handling, utf8 bases support

### DIFF
--- a/modules/slugs/README.md
+++ b/modules/slugs/README.md
@@ -19,21 +19,8 @@ If you want to translate also the base permastructs (ex. *category*, *tag*, etc)
 ### I get a 404 error, what can I do?
 In the admin go to *Settings/Permalinks* or *Settings/Languages* (qTranslate) options and save.
 
-### I can't manage translations in Nav Menus.
-That's because language selector metabox is hidden, if you are in admin *nav menus* screen, press the button **Screen options** (on top and right) and after, check the option *Languages*. It will appear a **Language** meta box on top of the left sidebar.
-
 ### How to get the current url in a specific language?
 You can use `qts_get_url()`.
-
-## TODO
-In slug options you can change the bases for taxonomies and custom post types.  
-So, for example, you can change /category/ for /category/ for english and /categoria/ for spanish version.
-But these won't work:
-* slug with UTF8 characters in taxonomies bases: example:  /類別/... instead of /category/...
-  UTF8 in taxonomies works just fine: /category_zh/魚/
-* slug with UTF8 characters in custom post type bases : example:  /圖書/... instead of /books/...
-  UTF8 in custom post slugs works just fine: /tushu/彩繪中國經典名著/
-* translating custom post types archives with custom base name /tushu/ isn't working. Using UTF8 in the the default slug works as expected : /中國/
 
 ## Contributors
 

--- a/modules/slugs/includes/class-qtranslate-slug.php
+++ b/modules/slugs/includes/class-qtranslate-slug.php
@@ -353,13 +353,13 @@ class QtranslateSlug {
         global $q_config;
         global $wp;
 
-        if ( isset( $query[ 'error' ] ) && isset( $wp->matched_query ) ){
-            unset( $query[ 'error' ] );
-            $query = array_merge ( wp_parse_args( $wp->matched_query ), $query );
+        if ( isset( $query['error'] ) && isset( $wp->matched_query ) ) {
+            unset( $query['error'] );
+            $query = array_merge( wp_parse_args( $wp->matched_query ), $query );
         }
 
         // -> home url
-        if ( empty( $query ) || isset( $query[ 'error' ] ) ):
+        if ( empty( $query ) || isset( $query['error'] ) ):
             $function = 'home_url';
             $id       = '';
 
@@ -399,12 +399,8 @@ class QtranslateSlug {
         // -> category
         elseif ( ( isset( $query['category_name'] ) || isset( $query['cat'] ) ) ):
             if ( isset( $query['category_name'] ) ) {
-                if ( empty( $query['category_name'] ) ) {
-                    $term_slug = $this->get_last_slash( $wp->request );
-                } else {
-                    $term_slug = $this->get_last_slash( $query['category_name'] );
-                }
-                $term = $this->get_term_by( 'slug', $term_slug, 'category' );
+                $term_slug = $this->get_last_slash( empty( $query['category_name'] ) ? $wp->request : $query['category_name'] );
+                $term      = $this->get_term_by( 'slug', $term_slug, 'category' );
             } else {
                 $term = get_term( $query['cat'], 'category' );
             }
@@ -429,8 +425,8 @@ class QtranslateSlug {
             $id           = $term->term_id;
             $query['tag'] = $term->slug;
             $function     = 'get_tag_link';
-        else:
 
+        else:
             // -> custom post type
             foreach ( $this->get_public_post_types() as $post_type ) {
                 if ( array_key_exists( $post_type->name, $query ) && ! in_array( $post_type->name, array(
@@ -442,7 +438,7 @@ class QtranslateSlug {
                 }
             }
 
-            if ( isset( $query['post_type'] ) ){
+            if ( isset( $query['post_type'] ) ) {
                 if ( count( $query ) == 1 ) {
                     $function = 'get_post_type_archive_link';
                     $id       = $query['post_type'];
@@ -463,12 +459,7 @@ class QtranslateSlug {
             // -> taxonomy
             foreach ( $this->get_public_taxonomies() as $item ):
                 if ( isset( $query[ $item->name ] ) ) {
-                     if ( empty( $query[ $item->name ] ) ) {
-                        $term_slug = $this->get_last_slash( $wp->request );
-                    } else {
-                        $term_slug = $this->get_last_slash( $query[ $item->name ] );
-                    }
-
+                    $term_slug = $this->get_last_slash( empty( $query[ $item->name ] ) ? $wp->request : $query[ $item->name ] );
                     $term      = $this->get_term_by( 'slug', $term_slug, $item->name );
                     if ( ! $term ) {
                         return $query;
@@ -972,16 +963,10 @@ class QtranslateSlug {
         $page_path     = str_replace( '%2F', '/', $page_path );
         $page_path     = str_replace( '%20', ' ', $page_path );
         $parts         = explode( '/', trim( $page_path, '/' ) );
-        $parts         = array_map(
-                            function ( $a ) {
-                                global $wpdb;
-                                return sanitize_title_for_query(
-                                    $wpdb->remove_placeholder_escape(
-                                        esc_sql( $a )
-                                    )
-                                );
-                            },
-                            $parts );
+        $parts         = array_map( function ( $a ) use ( $wpdb ) {
+            return sanitize_title_for_query( $wpdb->remove_placeholder_escape( esc_sql( $a ) ) );
+        },
+            $parts );
         $in_string     = "'" . implode( "','", $parts ) . "'";
         $meta_key      = QTS_META_PREFIX . $this->get_temp_lang();
         $post_type_sql = $post_type;


### PR DESCRIPTION
* Fix logic breaking query variables getter in filter_request. Former logic overwrote $query arg with $wp->matched_query. Current one merges the two (preserving possible query vars) only if needed (404 is detected) and removes only the error key.
* Fix language switch links in case of 404 to point to home page instead of current not existing resource.
* Reorder tests and incorporate in single if block
* Add support for utf8 bases (fallback to $wp->request).