### PR TITLE
WC: fix attribute edit page hidden fields

### DIFF
--- a/modules/slugs/includes/qtranslate-slug-admin.php
+++ b/modules/slugs/includes/qtranslate-slug-admin.php
@@ -44,6 +44,7 @@ function qts_taxonomies_hooks() {
 
     if ( QTX_Module_Loader::is_module_active( 'woo-commerce' ) ) {
         add_action( 'woocommerce_after_add_attribute_fields', 'qts_show_add_term_fields' );
+        add_action( 'woocommerce_after_edit_attribute_fields', 'qts_show_edit_term_fields' );
     }
 }
 
@@ -433,12 +434,17 @@ function qts_hide_term_slug_box() {
             break;
         case 'edit.php':
             // Handle WooCommerce edit product attributes page.
-            if ( isset( $_GET['page'] ) && $_GET['page'] == 'product_attributes' && ! isset( $_GET['edit'] ) ) {
+            if ( isset( $_GET['page'] ) && $_GET['page'] == 'product_attributes' ) {
                 $id = 'attribute_name';
                 // TODO: actual slug column to be added (javascript seems the only way currently). For the time being, possibly overridden slugs column is hidden.
-                $additional_jquery =
-                    "$('table tr th:nth-child(2)').hide()" . PHP_EOL .
-                    "$('table tr td:nth-child(2)').hide()" . PHP_EOL;
+                if ( isset( $_GET['edit'] ) ) {
+                    $additional_jquery =
+                        "$(\"#" . $id . "\").parent().prev(\"th\").hide()" . PHP_EOL;
+                } else {
+                    $additional_jquery =
+                        "$('table tr th:nth-child(2)').hide()" . PHP_EOL .
+                        "$('table tr td:nth-child(2)').hide()" . PHP_EOL;
+                }
             }
             break;
         default:

--- a/modules/slugs/includes/qtranslate-slug-admin.php
+++ b/modules/slugs/includes/qtranslate-slug-admin.php
@@ -433,7 +433,7 @@ function qts_hide_term_slug_box() {
             break;
         case 'edit.php':
             // Handle WooCommerce edit product attributes page.
-            if ( isset( $_GET['page'] ) && $_GET['page'] == 'product_attributes' ) {
+            if ( isset( $_GET['page'] ) && $_GET['page'] == 'product_attributes' && ! isset( $_GET['edit'] ) ) {
                 $id = 'attribute_name';
                 // TODO: actual slug column to be added (javascript seems the only way currently). For the time being, possibly overridden slugs column is hidden.
                 $additional_jquery =

--- a/modules/slugs/includes/qtranslate-slug-admin.php
+++ b/modules/slugs/includes/qtranslate-slug-admin.php
@@ -435,12 +435,15 @@ function qts_hide_term_slug_box() {
         case 'edit.php':
             // Handle WooCommerce edit product attributes page.
             if ( isset( $_GET['page'] ) && $_GET['page'] == 'product_attributes' ) {
+                // Hide the regular slug input field.
                 $id = 'attribute_name';
-                // TODO: actual slug column to be added (javascript seems the only way currently). For the time being, possibly overridden slugs column is hidden.
                 if ( isset( $_GET['edit'] ) ) {
+                    // Hide the slug header left of the input field.
                     $additional_jquery =
                         "$(\"#" . $id . "\").parent().prev(\"th\").hide()" . PHP_EOL;
                 } else {
+                    // Hide the slug column in the table.
+                    // TODO: actual slug column to be added (javascript seems the only way currently). For the time being, possibly overridden slugs column is hidden.
                     $additional_jquery =
                         "$('table tr th:nth-child(2)').hide()" . PHP_EOL .
                         "$('table tr td:nth-child(2)').hide()" . PHP_EOL;
@@ -452,7 +455,7 @@ function qts_hide_term_slug_box() {
     endswitch;
 
     echo "<!-- QTS remove slug box -->" . PHP_EOL;
-    echo "<script type=\"text/javascript\" charset=\"utf-8\">" . PHP_EOL;
+    echo "<script>" . PHP_EOL;
     echo "  jQuery(document).ready(function($){" . PHP_EOL;
     echo "      $(\"#" . $id . "\").parent().hide();" . PHP_EOL;
     echo "      $(\".form-field td #slug\").parent().parent().hide();" . PHP_EOL;

--- a/modules/woo-commerce/qwc-admin.php
+++ b/modules/woo-commerce/qwc-admin.php
@@ -44,8 +44,6 @@ function qtranxf_wc_add_filters_admin() {
 
     add_filter( 'woocommerce_attribute_taxonomies' , 'qtranxf_useCurrentLanguageIfNotFoundUseDefaultLanguage' );
     add_filter( 'woocommerce_variation_option_name' , 'qtranxf_useCurrentLanguageIfNotFoundUseDefaultLanguage' );
-    //TODO: check upstream in QTX core if a cleaner approach can be adopted
-    add_action( 'woocommerce_after_edit_attribute_fields', function(){echo "<script>jQuery(document).ready(function(){jQuery(\"td\").show()})</script>";});
 }
 
 qtranxf_wc_add_filters_admin();

--- a/modules/woo-commerce/qwc-admin.php
+++ b/modules/woo-commerce/qwc-admin.php
@@ -41,9 +41,11 @@ function qtranxf_wc_add_filters_admin() {
     foreach ( $email_common as $name => $priority ) {
         add_filter( $name, 'qtranxf_useCurrentLanguageIfNotFoundUseDefaultLanguage', $priority );
     }
-    
+
     add_filter( 'woocommerce_attribute_taxonomies' , 'qtranxf_useCurrentLanguageIfNotFoundUseDefaultLanguage' );
     add_filter( 'woocommerce_variation_option_name' , 'qtranxf_useCurrentLanguageIfNotFoundUseDefaultLanguage' );
+    //TODO: check upstream in QTX core if a cleaner approach can be adopted
+    add_action( 'woocommerce_after_edit_attribute_fields', function(){echo "<script>jQuery(document).ready(function(){jQuery(\"td\").show()})</script>";});
 }
 
 qtranxf_wc_add_filters_admin();


### PR DESCRIPTION
Display the set of QTS slugs when editing (or adding) a WC product attribute.
Hide the regular slug.