### PR TITLE
QTS: remove slug fields for WC attributes add/edit page

### DIFF
--- a/modules/slugs/includes/qtranslate-slug-admin.php
+++ b/modules/slugs/includes/qtranslate-slug-admin.php
@@ -43,8 +43,8 @@ function qts_taxonomies_hooks() {
     }
 
     if ( QTX_Module_Loader::is_module_active( 'woo-commerce' ) ) {
-        add_action( 'woocommerce_after_add_attribute_fields', 'qts_show_add_term_fields' );
-        add_action( 'woocommerce_after_edit_attribute_fields', 'qts_show_edit_term_fields' );
+        add_action( 'woocommerce_after_add_attribute_fields', 'qts_show_add_taxonomy_slugs_option_link' );
+        add_action( 'woocommerce_after_edit_attribute_fields', 'qts_show_edit_taxonomy_slugs_option_link' );
     }
 }
 
@@ -426,6 +426,40 @@ function qts_show_edit_term_fields( $term ) {
     <tr class="form-field term-slug-wrap">
         <th><?php _e( 'Slugs per language', 'qtranslate' ) ?></th>
         <td><?php qts_show_list_term_fields( $term ); ?></td>
+    </tr>
+    <?php
+}
+
+/**
+ * Display link to slugs settings for add custom tax admin page (e.g. WooCommerce product attributes).
+ *
+ */
+function qts_show_add_taxonomy_slugs_option_link() {
+    ?>
+    <div class="form-field term-slug-wrap">
+        <label><?php _e( 'Slugs per language', 'qtranslate' ) ?></label>
+        <?php
+        //TODO: link destination should not be hardcoded here, but currently $options_uri property is private in QTX_Admin_Settings class (base options page) and module id is hardcoded independently from module definitions in QTX_Admin_Module class (module href).
+        echo sprintf( "<p>" . __( 'Multilanguage slugs can be set up in <a href="%s">slugs module settings</a> once the new item is added.', 'qtranslate' ) . "</p>", admin_url( 'options-general.php?page=qtranslate-xt#slugs' ) );
+        ?>
+    </div>
+    <?php
+}
+
+/**
+ * Display link to slugs settings for edit custom tax admin page (e.g. WooCommerce product attributes).
+ *
+ */
+function qts_show_edit_taxonomy_slugs_option_link() {
+    ?>
+    <tr class="form-field term-slug-wrap">
+        <th><?php _e( 'Slugs per language', 'qtranslate' ) ?></th>
+        <td>
+            <?php
+        //TODO: link destination should not be hardcoded here, but currently $options_uri property is private in QTX_Admin_Settings class (base options page) and module id is hardcoded independently from module definitions in QTX_Admin_Module class (module href).
+        echo sprintf( "<p>" . __( 'Multilanguage slugs can be set up in <a href="%s">slugs module settings</a>', 'qtranslate' ) . "</p>", admin_url( 'options-general.php?page=qtranslate-xt#slugs' ) );
+        ?>
+        </td>
     </tr>
     <?php
 }


### PR DESCRIPTION
Replace slug fields from WC attribute add/edit admin pages with the link to the relevant existing slugs module settings page.