### PR TITLE
QTS: fix conflict pages/posts in filter_request

### DIFF
--- a/modules/slugs/includes/class-qtranslate-slug.php
+++ b/modules/slugs/includes/class-qtranslate-slug.php
@@ -942,12 +942,12 @@ class QtranslateSlug {
                 $struct = $wp_rewrite->extra_permastructs[ $name ];
                 if ( is_array( $struct ) ) {
                     if ( count( $struct ) == 2 ) {
-                        $rules = $wp_rewrite->generate_rewrite_rules( "/$base/%$name%", $struct[1] );
+                        $rules = $wp_rewrite->generate_rewrite_rules( "/".rawurldecode($base)."/%".rawurldecode($name)."%", $struct[1] );
                     } else {
-                        $rules = $wp_rewrite->generate_rewrite_rules( "/$base/%$name%", $struct['ep_mask'], $struct['paged'], $struct['feed'], $struct['forcomments'], $struct['walk_dirs'], $struct['endpoints'] );
+                        $rules = $wp_rewrite->generate_rewrite_rules( "/".rawurldecode($base)."/%".rawurldecode($name)."%", $struct['ep_mask'], $struct['paged'], $struct['feed'], $struct['forcomments'], $struct['walk_dirs'], $struct['endpoints'] );
                     }
                 } else {
-                    $rules = $wp_rewrite->generate_rewrite_rules( "/$base/%$name%" );
+                    $rules = $wp_rewrite->generate_rewrite_rules( "/".rawurldecode($base)."/%".rawurldecode($name)."%" );
                 }
                 $wp_rewrite->rules = array_merge( $rules, $wp_rewrite->rules );
             endif;

--- a/modules/slugs/includes/class-qtranslate-slug.php
+++ b/modules/slugs/includes/class-qtranslate-slug.php
@@ -398,7 +398,8 @@ class QtranslateSlug {
             $function          = 'get_page_link';
 
         // -> category
-        elseif ( ( isset( $query['category_name'] ) || isset( $query['cat'] ) ) ):
+        // If 'name' key is defined, query is relevant to a post with a /%category%/%postname%/ permalink structure and will be captured later.
+        elseif ( ( ( isset( $query['category_name'] ) || isset( $query['cat'] ) ) && ! isset($query['name'] ) ) ):
             if ( isset( $query['category_name'] ) ) {
                 $term_slug = $this->get_last_slash( empty( $query['category_name'] ) ? $wp->request : $query['category_name'] );
                 $term      = $this->get_term_by( 'slug', $term_slug, 'category' );


### PR DESCRIPTION
As the information that query is relevant to a page instead of a post is only included in `$wp->matched_query`, merge with `$query` argument must always occur.
If page is identified, `name` key is removed as it is used to retrieve posts instead.
Posts identification test is moved at the end of the block to avoid other conflicts with more specific tests (e.g. custom post types).