### PR TITLE
Rename module classes with `QTX_Module` prefix

### DIFF
--- a/modules/acf/acf.php
+++ b/modules/acf/acf.php
@@ -10,4 +10,4 @@ define( 'ACF_QTRANSLATE_PLUGIN', __FILE__ );
 define( 'ACF_QTRANSLATE_PLUGIN_DIR', plugin_dir_path( ACF_QTRANSLATE_PLUGIN ) );
 
 require_once ACF_QTRANSLATE_PLUGIN_DIR . 'src/plugin.php';
-new acf_qtranslate_plugin;
+new QTX_Module_Acf_Plugin;

--- a/modules/acf/src/acf_5/acf.php
+++ b/modules/acf/src/acf_5/acf.php
@@ -2,18 +2,18 @@
 
 require_once ACF_QTRANSLATE_PLUGIN_DIR . 'src/acf_interface.php';
 
-class acf_qtranslate_acf_5 implements acf_qtranslate_acf_interface {
+class QTX_Module_Acf_V5 implements QTX_Module_Acf_Interface {
 
     /**
      * The plugin instance
-     * @var acf_qtranslate_plugin
+     * @var QTX_Module_Acf_Plugin
      */
     protected $plugin;
 
     /**
      * Constructor
      *
-     * @param acf_qtranslate_plugin $plugin
+     * @param QTX_Module_Acf_Plugin $plugin
      */
     public function __construct( $plugin ) {
         $this->plugin = $plugin;
@@ -35,13 +35,13 @@ class acf_qtranslate_acf_5 implements acf_qtranslate_acf_interface {
         require_once ACF_QTRANSLATE_PLUGIN_DIR . 'src/acf_5/fields/url.php';
         require_once ACF_QTRANSLATE_PLUGIN_DIR . 'src/acf_5/fields/wysiwyg.php';
 
-        acf()->fields->register_field_type( new acf_qtranslate_acf_5_file( $this->plugin ) );
-        acf()->fields->register_field_type( new acf_qtranslate_acf_5_image( $this->plugin ) );
-        acf()->fields->register_field_type( new acf_qtranslate_acf_5_post_object( $this->plugin ) );
-        acf()->fields->register_field_type( new acf_qtranslate_acf_5_text( $this->plugin ) );
-        acf()->fields->register_field_type( new acf_qtranslate_acf_5_textarea( $this->plugin ) );
-        acf()->fields->register_field_type( new acf_qtranslate_acf_5_url( $this->plugin ) );
-        acf()->fields->register_field_type( new acf_qtranslate_acf_5_wysiwyg( $this->plugin ) );
+        acf()->fields->register_field_type( new QTX_Module_Acf_V5_File( $this->plugin ) );
+        acf()->fields->register_field_type( new QTX_Module_Acf_V5_Image( $this->plugin ) );
+        acf()->fields->register_field_type( new QTX_Module_Acf_V5_Post_Object( $this->plugin ) );
+        acf()->fields->register_field_type( new QTX_Module_Acf_V5_Text( $this->plugin ) );
+        acf()->fields->register_field_type( new QTX_Module_Acf_V5_Textarea( $this->plugin ) );
+        acf()->fields->register_field_type( new QTX_Module_Acf_V5_Url( $this->plugin ) );
+        acf()->fields->register_field_type( new QTX_Module_Acf_V5_Wysiwyg( $this->plugin ) );
     }
 
     /**

--- a/modules/acf/src/acf_5/fields/file.php
+++ b/modules/acf/src/acf_5/fields/file.php
@@ -1,17 +1,17 @@
 <?php
 
-class acf_qtranslate_acf_5_file extends acf_field_file {
+class QTX_Module_Acf_V5_File extends acf_field_file {
 
     /**
      * The plugin instance
-     * @var acf_qtranslate_plugin
+     * @var QTX_Module_Acf_Plugin
      */
     protected $plugin;
 
     /**
      * Constructor
      *
-     * @param acf_qtranslate_plugin $plugin
+     * @param QTX_Module_Acf_Plugin $plugin
      */
     function __construct( $plugin ) {
         $this->plugin = $plugin;

--- a/modules/acf/src/acf_5/fields/image.php
+++ b/modules/acf/src/acf_5/fields/image.php
@@ -1,17 +1,17 @@
 <?php
 
-class acf_qtranslate_acf_5_image extends acf_field_image {
+class QTX_Module_Acf_V5_Image extends acf_field_image {
 
     /**
      * The plugin instance
-     * @var acf_qtranslate_plugin
+     * @var QTX_Module_Acf_Plugin
      */
     protected $plugin;
 
     /**
      * Constructor
      *
-     * @param acf_qtranslate_plugin $plugin
+     * @param QTX_Module_Acf_Plugin $plugin
      */
     function __construct( $plugin ) {
         $this->plugin = $plugin;

--- a/modules/acf/src/acf_5/fields/post_object.php
+++ b/modules/acf/src/acf_5/fields/post_object.php
@@ -1,17 +1,17 @@
 <?php
 
-class acf_qtranslate_acf_5_post_object extends acf_field_post_object {
+class QTX_Module_Acf_V5_Post_Object extends acf_field_post_object {
 
     /**
      * The plugin instance
-     * @var acf_qtranslate_plugin
+     * @var QTX_Module_Acf_Plugin
      */
     protected $plugin;
 
     /**
      * Constructor
      *
-     * @param acf_qtranslate_plugin $plugin
+     * @param QTX_Module_Acf_Plugin $plugin
      */
     function __construct( $plugin ) {
         $this->plugin = $plugin;

--- a/modules/acf/src/acf_5/fields/text.php
+++ b/modules/acf/src/acf_5/fields/text.php
@@ -1,17 +1,17 @@
 <?php
 
-class acf_qtranslate_acf_5_text extends acf_field_text {
+class QTX_Module_Acf_V5_Text extends acf_field_text {
 
     /**
      * The plugin instance
-     * @var acf_qtranslate_plugin
+     * @var QTX_Module_Acf_Plugin
      */
     protected $plugin;
 
     /**
      * Constructor
      *
-     * @param acf_qtranslate_plugin $plugin
+     * @param QTX_Module_Acf_Plugin $plugin
      */
     function __construct( $plugin ) {
         $this->plugin = $plugin;

--- a/modules/acf/src/acf_5/fields/textarea.php
+++ b/modules/acf/src/acf_5/fields/textarea.php
@@ -1,17 +1,17 @@
 <?php
 
-class acf_qtranslate_acf_5_textarea extends acf_field_textarea {
+class QTX_Module_Acf_V5_Textarea extends acf_field_textarea {
 
     /**
      * The plugin instance
-     * @var acf_qtranslate_plugin
+     * @var QTX_Module_Acf_Plugin
      */
     protected $plugin;
 
     /**
      * Constructor
      *
-     * @param acf_qtranslate_plugin $plugin
+     * @param QTX_Module_Acf_Plugin $plugin
      */
     function __construct( $plugin ) {
         $this->plugin = $plugin;

--- a/modules/acf/src/acf_5/fields/url.php
+++ b/modules/acf/src/acf_5/fields/url.php
@@ -1,17 +1,17 @@
 <?php
 
-class acf_qtranslate_acf_5_url extends acf_field_url {
+class QTX_Module_Acf_V5_Url extends acf_field_url {
 
     /**
      * The plugin instance
-     * @var acf_qtranslate_plugin
+     * @var QTX_Module_Acf_Plugin
      */
     protected $plugin;
 
     /**
      * Constructor
      *
-     * @param acf_qtranslate_plugin $plugin
+     * @param QTX_Module_Acf_Plugin $plugin
      */
     function __construct( $plugin ) {
         $this->plugin = $plugin;

--- a/modules/acf/src/acf_5/fields/wysiwyg.php
+++ b/modules/acf/src/acf_5/fields/wysiwyg.php
@@ -1,17 +1,17 @@
 <?php
 
-class acf_qtranslate_acf_5_wysiwyg extends acf_field_wysiwyg {
+class QTX_Module_Acf_V5_Wysiwyg extends acf_field_wysiwyg {
 
     /**
      * The plugin instance
-     * @var acf_qtranslate_plugin
+     * @var QTX_Module_Acf_Plugin
      */
     protected $plugin;
 
     /**
      * Constructor
      *
-     * @param acf_qtranslate_plugin $plugin
+     * @param QTX_Module_Acf_Plugin $plugin
      */
     function __construct( $plugin ) {
         $this->plugin = $plugin;

--- a/modules/acf/src/acf_interface.php
+++ b/modules/acf/src/acf_interface.php
@@ -1,6 +1,6 @@
 <?php
 
-interface acf_qtranslate_acf_interface {
+interface QTX_Module_Acf_Interface {
 
     /**
      * Get the visible ACF fields

--- a/modules/acf/src/plugin.php
+++ b/modules/acf/src/plugin.php
@@ -1,10 +1,10 @@
 <?php
 
-class acf_qtranslate_plugin {
+class QTX_Module_Acf_Plugin {
 
     /**
      * An ACF instance
-     * @var acf_qtranslate_acf_interface
+     * @var QTX_Module_Acf_Interface
      */
     protected $acf;
 
@@ -34,7 +34,7 @@ class acf_qtranslate_plugin {
         if ( ! $plugin_loaded && $this->acf_enabled() ) {
             if ( $this->acf_major_version() === 5 ) {
                 require_once ACF_QTRANSLATE_PLUGIN_DIR . 'src/acf_5/acf.php';
-                $this->acf = new acf_qtranslate_acf_5( $this );
+                $this->acf = new QTX_Module_Acf_V5( $this );
             }
             $plugin_loaded = true;
         }

--- a/modules/gravity-forms/gravity-forms.php
+++ b/modules/gravity-forms/gravity-forms.php
@@ -7,7 +7,7 @@
  * @link https://michel.weimerskirch.net
  */
 
-class qTranslateSupportForGravityforms {
+class QTX_Module_Gravity_Forms {
     public function __construct() {
         add_filter( 'gform_pre_render', array( $this, 'gform_pre_render' ) );
         add_filter( 'gform_pre_submission_filter', array( $this, 'gform_pre_render' ) );
@@ -156,4 +156,4 @@ class qTranslateSupportForGravityforms {
     }
 }
 
-new qTranslateSupportForGravityforms();
+new QTX_Module_Gravity_Forms();

--- a/modules/jetpack/jetpack.php
+++ b/modules/jetpack/jetpack.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-class QTX_Jetpack {
+class QTX_Module_Jetpack {
     public function __construct() {
         add_filter( 'jetpack_relatedposts_returned_results', array( $this, 'translate_related_posts' ) );
     }
@@ -30,4 +30,4 @@ class QTX_Jetpack {
 
 }
 
-new QTX_Jetpack();
+new QTX_Module_Jetpack();

--- a/modules/slugs/qtx_module_slugs.php
+++ b/modules/slugs/qtx_module_slugs.php
@@ -3,7 +3,7 @@
 /**
  * Main class for translation of slugs, setting up hooks for front-side.
  */
-class QTX_Slugs {
+class QTX_Module_Slugs {
     /**
      * Stores options slugs from database.
      * @var array

--- a/modules/slugs/slugs.php
+++ b/modules/slugs/slugs.php
@@ -1,11 +1,11 @@
 <?php
 const QTX_SLUGS_META_PREFIX = 'qtranslate_slug_';   // The language code is appended.
 
-include_once( dirname( __FILE__ ) . '/src/slugs-class-slugs.php' );
+include_once( dirname( __FILE__ ) . '/qtx_module_slugs.php' );
 include_once( dirname( __FILE__ ) . '/src/slugs-utils.php' );
 
 global $qtranslate_slugs;
-$qtranslate_slugs = new QTX_Slugs();
+$qtranslate_slugs = new QTX_Module_Slugs();
 
 if ( is_admin() ) {
     include_once( dirname( __FILE__ ) . '/admin/slugs-admin.php' );


### PR DESCRIPTION
Adopt a consistent naming convention with a fixed prefix:
- `QTX_Module_Acf` (several classes)
- `QTX_Module_Gravity_Forms`
- `QTX_Module_Jetpack`
- `QTX_Module_Slugs`

For now use snake case to keep consistent, may evolve later.
Rename the main slugs class file and move it down.