### PR TITLE
Don't show slug metabox on woo shop_orders and shop_coupon pages

### DIFF
--- a/modules/slugs/admin/slugs-admin.php
+++ b/modules/slugs/admin/slugs-admin.php
@@ -9,10 +9,7 @@ add_filter( 'wp_get_object_terms', 'qtranxf_slugs_get_object_terms', 0, 4 );
 add_filter( 'get_terms', 'qtranxf_slugs_get_terms', 0, 3 );
 
 // admin actions
-
-// add slug metabox
 add_action( 'add_meta_boxes', 'qtranxf_slugs_add_slug_meta_box' );
-
 add_action( 'save_post', 'qtranxf_slugs_save_postdata', 605, 2 );
 add_action( 'edit_attachment', 'qtranxf_slugs_save_postdata' );
 add_action( 'created_term', 'qtranxf_slugs_save_term', 605, 3 );
@@ -21,6 +18,7 @@ add_action( 'admin_head', 'qtranxf_slugs_hide_term_slug_box', 900 );
 add_action( 'init', 'qtranxf_slugs_taxonomies_hooks', 805 );
 add_action( 'admin_head', 'qtranxf_slugs_hide_quick_edit', 600 );
 add_action( 'qtranslate_save_config', 'qtranxf_slugs_ma_module_updated' );
+
 // plugin deactivation/uninstall
 register_deactivation_hook( QTRANSLATE_FILE, 'qtranxf_slugs_deactivate' );
 register_uninstall_hook( QTRANSLATE_FILE, 'qtranxf_slugs_uninstall' );
@@ -115,6 +113,8 @@ function qtranxf_slugs_deactivate() {
  */
 function qtranxf_slugs_add_slug_meta_box() {
     global $post_type;
+
+    // Exclude some WooCommerce shop pages
     $not_applicable_types = [
         'shop_coupon',
         'shop_order',

--- a/modules/slugs/admin/slugs-admin.php
+++ b/modules/slugs/admin/slugs-admin.php
@@ -11,11 +11,7 @@ add_filter( 'get_terms', 'qtranxf_slugs_get_terms', 0, 3 );
 // admin actions
 
 // add slug metabox
-$curr_post_type = $_GET[ 'post_type' ] ? $_GET[ 'post_type' ] : get_post_type( intval( $_GET[ 'post' ] ) );
-if ( $curr_post_type !== 'shop_order' && $curr_post_type !== 'shop_coupon' )
-{
-    add_action( 'add_meta_boxes', 'qtranxf_slugs_add_slug_meta_box' );
-}
+add_action( 'add_meta_boxes', 'qtranxf_slugs_add_slug_meta_box' );
 
 add_action( 'save_post', 'qtranxf_slugs_save_postdata', 605, 2 );
 add_action( 'edit_attachment', 'qtranxf_slugs_save_postdata' );
@@ -118,6 +114,13 @@ function qtranxf_slugs_deactivate() {
  * Creates a metabox for every post type available.
  */
 function qtranxf_slugs_add_slug_meta_box() {
+    global $post_type;
+    $not_applicable_types=[
+        'shop_coupon',
+        'shop_order',
+    ];
+    if ( isset( $post_type ) && in_array( $post_type , $not_applicable_types ) )  return;
+    
     remove_meta_box( 'slugdiv', null, 'normal' );
     add_meta_box( 'qts_sectionid', __( 'Slugs per language', 'qtranslate' ), 'qtranxf_slugs_draw_meta_box', null, 'side', 'high' );
 }

--- a/modules/slugs/admin/slugs-admin.php
+++ b/modules/slugs/admin/slugs-admin.php
@@ -11,7 +11,7 @@ add_filter( 'get_terms', 'qtranxf_slugs_get_terms', 0, 3 );
 // admin actions
 
 // add slug metabox
-$curr_post_type = $_GET[ 'post_type' ] ? $curr_post_type = $_GET[ 'post_type' ] : get_post_type( intval( $_GET[ 'post' ] ) );
+$curr_post_type = $_GET[ 'post_type' ] ? $_GET[ 'post_type' ] : get_post_type( intval( $_GET[ 'post' ] ) );
 if ( $curr_post_type !== 'shop_order' && $curr_post_type !== 'shop_coupon' )
 {
     add_action( 'add_meta_boxes', 'qtranxf_slugs_add_slug_meta_box' );

--- a/modules/slugs/admin/slugs-admin.php
+++ b/modules/slugs/admin/slugs-admin.php
@@ -115,12 +115,14 @@ function qtranxf_slugs_deactivate() {
  */
 function qtranxf_slugs_add_slug_meta_box() {
     global $post_type;
-    $not_applicable_types=[
+    $not_applicable_types = [
         'shop_coupon',
         'shop_order',
     ];
-    if ( isset( $post_type ) && in_array( $post_type , $not_applicable_types ) )  return;
-    
+    if ( isset( $post_type ) && in_array( $post_type, $not_applicable_types ) ) {
+        return;
+    }
+
     remove_meta_box( 'slugdiv', null, 'normal' );
     add_meta_box( 'qts_sectionid', __( 'Slugs per language', 'qtranslate' ), 'qtranxf_slugs_draw_meta_box', null, 'side', 'high' );
 }

--- a/modules/slugs/admin/slugs-admin.php
+++ b/modules/slugs/admin/slugs-admin.php
@@ -7,8 +7,16 @@ include_once( dirname( __FILE__ ) . '/slugs-settings.php' );
 // add filters
 add_filter( 'wp_get_object_terms', 'qtranxf_slugs_get_object_terms', 0, 4 );
 add_filter( 'get_terms', 'qtranxf_slugs_get_terms', 0, 3 );
+
 // admin actions
-add_action( 'add_meta_boxes', 'qtranxf_slugs_add_slug_meta_box' );
+
+// add slug metabox
+$curr_post_type = $_GET[ 'post_type' ] ?? get_post_type( intval( $_GET[ 'post' ] ) );
+if ( $curr_post_type !== 'shop_order' && $curr_post_type !== 'shop_coupon' )
+{
+    add_action( 'add_meta_boxes', 'qtranxf_slugs_add_slug_meta_box' );
+}
+
 add_action( 'save_post', 'qtranxf_slugs_save_postdata', 605, 2 );
 add_action( 'edit_attachment', 'qtranxf_slugs_save_postdata' );
 add_action( 'created_term', 'qtranxf_slugs_save_term', 605, 3 );

--- a/modules/slugs/admin/slugs-admin.php
+++ b/modules/slugs/admin/slugs-admin.php
@@ -11,7 +11,7 @@ add_filter( 'get_terms', 'qtranxf_slugs_get_terms', 0, 3 );
 // admin actions
 
 // add slug metabox
-$curr_post_type = $_GET[ 'post_type' ] ?? get_post_type( intval( $_GET[ 'post' ] ) );
+$curr_post_type = $_GET[ 'post_type' ] ? $curr_post_type = $_GET[ 'post_type' ] : get_post_type( intval( $_GET[ 'post' ] ) );
 if ( $curr_post_type !== 'shop_order' && $curr_post_type !== 'shop_coupon' )
 {
     add_action( 'add_meta_boxes', 'qtranxf_slugs_add_slug_meta_box' );


### PR DESCRIPTION
The slug metaboxes might not be necessary for the woocommerce orders and coupon pages...