### PR TITLE
Add function to check if a request is a GraphQL call.

### DIFF
--- a/qtranslate_core.php
+++ b/qtranslate_core.php
@@ -215,8 +215,8 @@ function qtranxf_detect_language( &$url_info ) {
 
     $url_info['language'] = $lang;
 
-    // REST calls should be deterministic (stateless), no special language detection e.g. based on cookie
-    $url_info['set_cookie'] = ! wp_doing_ajax() && ! qtranxf_is_rest_request_expected();
+    // REST and GraphQL API calls should be deterministic (stateless), no special language detection e.g. based on cookie
+    $url_info['set_cookie'] = ! wp_doing_ajax() && ! qtranxf_is_rest_request_expected() && ! qtranxf_is_graphql_request_expected();
 
     /**
      * Hook for possible other methods
@@ -435,6 +435,7 @@ function qtranxf_detect_language_front( &$url_info ) {
 
     if ( ! isset( $url_info['doredirect'] )
          && ( ! qtranxf_is_rest_request_expected() ) // fallback case where language can be read from cookie with REST
+         && ( ! qtranxf_is_graphql_request_expected() )
          && ( ! $q_config['hide_default_language'] || $lang != $q_config['default_language'] )
          && ( ! qtranxf_language_neutral_path( $url_info['wp-path'] ) )
     ) {

--- a/qtranslate_utils.php
+++ b/qtranslate_utils.php
@@ -576,6 +576,16 @@ function qtranxf_is_rest_request_expected() {
 }
 
 /**
+ * Evaluate if the request URI leads to a GraphQL API call.
+ *
+ * @return bool
+ * @see is_graphql_http_request in https://github.com/wp-graphql/wp-graphql/blob/develop/src/Router.php
+ */
+function qtranxf_is_graphql_request_expected() {
+    return function_exists( 'is_graphql_http_request' ) && is_graphql_http_request();
+}
+
+/**
  * Evaluate if the current request allows HTTP redirection.
  * Admin requests (WP_ADMIN, DOING_AJAX, WP_CLI, DOING_CRON) or REST calls should not be redirected.
  *
@@ -584,6 +594,7 @@ function qtranxf_is_rest_request_expected() {
 function qtranxf_can_redirect() {
     return ! is_admin() && ! wp_doing_ajax() && ! ( defined( 'WP_CLI' ) && WP_CLI ) && ! wp_doing_cron() && empty( $_POST )
            && ( ! qtranxf_is_rest_request_expected() )
+           && ( ! qtranxf_is_graphql_request_expected() )
            // TODO clarify: 'REDIRECT_*' needs more testing --> && !isset($_SERVER['REDIRECT_URL'])
            && ( ! isset( $_SERVER['REDIRECT_STATUS'] ) || $_SERVER['REDIRECT_STATUS'] == '200' );
 }


### PR DESCRIPTION
Specifically for wp-graphql plugin: https://github.com/wp-graphql/wp-graphql - 3.3k Github stars and 20k active installs.

Add function to check if a request is a GraphQL call, and, if GraphQL call then don't do redirect or set cookies.

Without this change, WPGraphQL does not function correctly. It's default endpoint of /graphql is redirected to /xx/graphql