### PR TITLE
Refactor date-time conversions using `qtranxf_intl_strftime`

### DIFF
--- a/admin/qtx_activation_hook.php
+++ b/admin/qtx_activation_hook.php
@@ -755,10 +755,10 @@ function qtranxf_clear_debug_log() {
 
 function qtranxf_activation_hook() {
     qtranxf_clear_debug_log();
-    if ( version_compare( PHP_VERSION, '5.4' ) < 0 ) {
+    if ( version_compare( PHP_VERSION, '5.5' ) < 0 ) {
         // Deactivate ourself
         load_plugin_textdomain( 'qtranslate', false, basename( QTRANSLATE_DIR ) . '/lang' );
-        $msg = sprintf( __( 'Plugin %s requires PHP version %s at least. This server instance runs PHP version %s. A PHP version %s or higher is recommended. The plugin has not been activated.', 'qtranslate' ), qtranxf_get_plugin_link(), '5.4', PHP_VERSION, '7.4' );
+        $msg = sprintf( __( 'Plugin %s requires PHP version %s at least. This server instance runs PHP version %s. A PHP version %s or higher is recommended. The plugin has not been activated.', 'qtranslate' ), qtranxf_get_plugin_link(), '5.5', PHP_VERSION, '8.1' );
         deactivate_plugins( plugin_basename( QTRANSLATE_FILE ) );
         wp_die( $msg );
     }

--- a/admin/qtx_admin_utils.php
+++ b/admin/qtx_admin_utils.php
@@ -448,11 +448,7 @@ function qtranxf_post_type_optional( $post_type ) {
 
 function qtranxf_json_encode( $o ) {
     _deprecated_function( __FUNCTION__, '3.10.0' );
-    if ( version_compare( PHP_VERSION, '5.4.0' ) >= 0 ) {
-        return json_encode( $o, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
-    }
-
-    return json_encode( $o );
+    return json_encode( $o, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
 }
 
 /**

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,13 @@
   "name": "qtranslate/qtranslate-xt",
   "description": "qTranslate-XT (eXTended): Adds user-friendly multilingual content support, stored in single post.",
   "type": "wordpress-plugin",
-  "keywords": [ "wordpress", "wordpress-plugin", "qtranslate-x", "qtranslate-xt", "i18n" ],
+  "keywords": [
+    "wordpress",
+    "wordpress-plugin",
+    "qtranslate-x",
+    "qtranslate-xt",
+    "i18n"
+  ],
   "homepage": "https://github.com/qtranslate/qtranslate-xt",
   "license": "GPL-2.0-or-later",
   "authors": [
@@ -40,7 +46,8 @@
   },
   "require": {
     "composer/installers": ">=1.0",
-    "php" : ">=5.4"
+    "php": ">=5.5",
+    "ext-intl": "*"
   },
   "extra": {
     "installer-name": "qtranslate-xt"

--- a/qtranslate.php
+++ b/qtranslate.php
@@ -54,7 +54,7 @@ if ( ! function_exists( 'add_filter' ) ) {
  * Designed as interface for other plugin integration. The documentation is available at
  * https://github.com/qtranslate/qtranslate-xt/wiki/Integration-Guide/
  */
-define( 'QTX_VERSION', '3.12.1' );
+define( 'QTX_VERSION', '3.13.0.dev.0' );
 
 if ( ! defined( 'QTRANSLATE_FILE' ) ) {
     define( 'QTRANSLATE_FILE', __FILE__ );

--- a/qtranslate_date_time.php
+++ b/qtranslate_date_time.php
@@ -444,63 +444,64 @@ function qtranxf_strftime( $format, $date, $default = '', $before = '', $after =
 /**
  * [Legacy] Generalized formatting of a date, applying qTranslate 'use_strftime' config.
  *
- * @param string $format
- * @param string $mysq_time date string in MySQL format
- * @param string $default
- * @param string $before
- * @param string $after
+ * @param string $format the requested user format.
+ * @param string $language_format the language date or time format, used by default or for configuration override.
+ * @param string $mysql_date_time date/time string in MySQL format.
+ * @param string $default_value default result in case the format conversion fails.
  *
  * @return string
  */
-function qtranxf_format_date( $format, $mysq_time, $default, $before = '', $after = '' ) {
+function qtranxf_format_date_time( $format, $language_format, $mysql_date_time, $default_value ) {
     global $q_config;
-    $ts = mysql2date( 'U', $mysq_time );
+    $timestamp = mysql2date( 'U', $mysql_date_time );
     if ( $format == 'U' ) {
-        return $ts;
+        return $timestamp;
     }
-
     // TODO: abandon strftime format in qTranslate.
     $format = qtranxf_useCurrentLanguageIfNotFoundUseDefaultLanguage( $format );
     if ( ! empty( $format ) && $q_config['use_strftime'] == QTX_STRFTIME ) {
         $format = qtranxf_convertDateFormatToStrftimeFormat( $format );
     }
-
-    $language_format = qtranxf_get_language_date_or_time_format( 'date_format' );
-    $date_format     = qtranxf_convertFormat( $format, $language_format );
-    $date_output     = empty( $date_format ) ? $default : qxtranxf_intl_strftime( $date_format, $ts, get_locale() );
-
-    return $before . $date_output . $after;
+    $date_format = qtranxf_convertFormat( $format, $language_format );
+    return empty( $date_format ) ? $default_value : qxtranxf_intl_strftime( $date_format, $timestamp, get_locale() );
 }
 
 /**
  * [Legacy] Generalized formatting of a date, applying qTranslate 'use_strftime' config.
  *
  * @param string $format
- * @param string $mysq_time time string in MySQL format
- * @param string $default
- * @param string $before
- * @param string $after
+ * @param string $mysql_time date string in MySQL format
+ * @param string $default_value default date value.
+ * @param string $before Deprecated. Not used, will be removed in a future version.
+ * @param string $after Deprecated. Not used, will be removed in a future version.
  *
  * @return string
  */
-function qtranxf_format_time( $format, $mysq_time, $default, $before = '', $after = '' ) {
-    global $q_config;
-    $ts = mysql2date( 'U', $mysq_time );
-    if ( $format == 'U' ) {
-        return $ts;
+function qtranxf_format_date( $format, $mysql_time, $default_value, $before = '', $after = '' ) {
+    if ( ! empty( $before ) || ! empty( $after ) ) {
+        _deprecated_argument( __FUNCTION__, '3.13.0' );
     }
+    $language_format = qtranxf_get_language_date_or_time_format( 'date_format' );
+    return qtranxf_format_date_time( $format, $language_format, $mysql_time, $default_value );
+}
 
-    // TODO: abandon strftime format in qTranslate.
-    $format = qtranxf_useCurrentLanguageIfNotFoundUseDefaultLanguage( $format );
-    if ( ! empty( $format ) && $q_config['use_strftime'] == QTX_STRFTIME ) {
-        $format = qtranxf_convertDateFormatToStrftimeFormat( $format );
+/**
+ * [Legacy] Generalized formatting of a date, applying qTranslate 'use_strftime' config.
+ *
+ * @param string $format
+ * @param string $mysql_time time string in MySQL format
+ * @param string $default_value default time value.
+ * @param string $before Deprecated. Not used, will be removed in a future version.
+ * @param string $after Deprecated. Not used, will be removed in a future version.
+ *
+ * @return string
+ */
+function qtranxf_format_time( $format, $mysql_time, $default_value, $before = '', $after = '' ) {
+    if ( ! empty( $before ) || ! empty( $after ) ) {
+        _deprecated_argument( __FUNCTION__, '3.13.0' );
     }
-
     $language_format = qtranxf_get_language_date_or_time_format( 'time_format' );
-    $time_format     = qtranxf_convertFormat( $format, $language_format );
-    $time_output     = empty( $time_format ) ? $default : qxtranxf_intl_strftime( $time_format, $ts, get_locale() );
-
-    return $before . $time_output . $after;
+    return qtranxf_format_date_time( $format, $language_format, $mysql_time, $default_value );
 }
 
 // @see get_the_date

--- a/qtranslate_date_time.php
+++ b/qtranslate_date_time.php
@@ -300,10 +300,9 @@ function qtranxf_convertFormat( $format, $default_format ) {
     $default_format = qtranxf_useCurrentLanguageIfNotFoundUseDefaultLanguage( $default_format );
     switch ( $q_config['use_strftime'] ) {
         case QTX_DATE:
-            if ( $format == '' ) {
+            if ( empty( $format ) ) {
                 $format = $default_format;
             }
-
             return qtranxf_convertDateFormatToStrftimeFormat( $format );
         case QTX_DATE_OVERRIDE:
             return qtranxf_convertDateFormatToStrftimeFormat( $default_format );
@@ -316,23 +315,35 @@ function qtranxf_convertFormat( $format, $default_format ) {
 }
 
 /**
+ * Return the date or time format set for the current language config or default language.
+ *
+ * @param string $config_key
+ *
+ * @return string
+ */
+function qtranxf_get_language_date_or_time_format( $config_key ) {
+    assert( $config_key == 'date_format' || $config_key == 'time_format' );
+    global $q_config;
+    if ( isset( $q_config[ $config_key ][ $q_config['language'] ] ) ) {
+        return $q_config[ $config_key ][ $q_config['language'] ];
+    } elseif ( isset( $q_config[ $config_key ][ $q_config['default_language'] ] ) ) {
+        return $q_config[ $config_key ][ $q_config['default_language'] ];
+    } else {
+        return '';
+    }
+}
+
+/**
  * [Legacy] Converter of a date format to "QTX-strftime" format, applying qTranslate 'use_strftime' configuration.
  *
  * @param string $format
  *
  * @return string
- * @deprecated Don't use strftime formats anymore, since strftime is deprecated from PHP8.1.
+ * @deprecated Use qtranxf_get_language_date_or_time_format.
  */
 function qtranxf_convertDateFormat( $format ) {
-    global $q_config;
-    if ( isset( $q_config['date_format'][ $q_config['language'] ] ) ) {
-        $default_format = $q_config['date_format'][ $q_config['language'] ];
-    } elseif ( isset( $q_config['date_format'][ $q_config['default_language'] ] ) ) {
-        $default_format = $q_config['date_format'][ $q_config['default_language'] ];
-    } else {
-        $default_format = '';
-    }
-
+    _deprecated_function( __FUNCTION__, '3.13.0', 'qtranxf_get_language_date_or_time_format' );
+    $default_format = qtranxf_get_language_date_or_time_format( 'date_format' );
     return qtranxf_convertFormat( $format, $default_format );
 }
 
@@ -342,18 +353,11 @@ function qtranxf_convertDateFormat( $format ) {
  * @param string $format
  *
  * @return string
- * @deprecated Don't use strftime formats anymore, since strftime is deprecated from PHP8.1.
+ * @deprecated Use qtranxf_get_language_date_or_time_format.
  */
 function qtranxf_convertTimeFormat( $format ) {
-    global $q_config;
-    if ( isset( $q_config['time_format'][ $q_config['language'] ] ) ) {
-        $default_format = $q_config['time_format'][ $q_config['language'] ];
-    } elseif ( isset( $q_config['time_format'][ $q_config['default_language'] ] ) ) {
-        $default_format = $q_config['time_format'][ $q_config['default_language'] ];
-    } else {
-        $default_format = '';
-    }
-
+    _deprecated_function( __FUNCTION__, '3.13.0', 'qtranxf_get_language_date_or_time_format' );
+    $default_format = qtranxf_get_language_date_or_time_format( 'time_format' );
     return qtranxf_convertFormat( $format, $default_format );
 }
 
@@ -367,7 +371,7 @@ function qtranxf_convertTimeFormat( $format ) {
  * @param string $after Text copied after result.
  *
  * @return mixed|string
- * @deprecated Don't use strftime formats anymore, since strftime is deprecated from PHP8.1.
+ * @deprecated Use qxtranxf_intl_strftime, since strftime is deprecated from PHP8.1.
  * @See https://www.php.net/manual/en/function.strftime.php
  */
 function qtranxf_strftime( $format, $date, $default = '', $before = '', $after = '' ) {
@@ -461,8 +465,9 @@ function qtranxf_format_date( $format, $mysq_time, $default, $before = '', $afte
         $format = qtranxf_convertDateFormatToStrftimeFormat( $format );
     }
 
-    $date_format = qtranxf_convertDateFormat( $format );  // strftime format for a date value
-    $date_output = empty( $date_format ) ? $default : qxtranxf_intl_strftime( $date_format, $ts, get_locale() );
+    $language_format = qtranxf_get_language_date_or_time_format( 'date_format' );
+    $date_format     = qtranxf_convertFormat( $format, $language_format );
+    $date_output     = empty( $date_format ) ? $default : qxtranxf_intl_strftime( $date_format, $ts, get_locale() );
 
     return $before . $date_output . $after;
 }
@@ -491,8 +496,9 @@ function qtranxf_format_time( $format, $mysq_time, $default, $before = '', $afte
         $format = qtranxf_convertDateFormatToStrftimeFormat( $format );
     }
 
-    $time_format = qtranxf_convertTimeFormat( $format ); // strftime format for a time value
-    $time_output = empty( $time_format ) ? $default : qxtranxf_intl_strftime( $time_format, $ts, get_locale() );
+    $language_format = qtranxf_get_language_date_or_time_format( 'time_format' );
+    $time_format     = qtranxf_convertFormat( $format, $language_format );
+    $time_output     = empty( $time_format ) ? $default : qxtranxf_intl_strftime( $time_format, $ts, get_locale() );
 
     return $before . $time_output . $after;
 }

--- a/qtranslate_date_time.php
+++ b/qtranslate_date_time.php
@@ -17,7 +17,7 @@
  * @param integer|string|DateTime $timestamp Timestamp
  *
  * @return string
- * @deprecated Avoid using this function, meant to transition from legacy strftime formats - might be removed.
+ * @todo Maybe deprecate. Avoid using this function, meant to transition from legacy strftime formats.
  * @see https://gist.github.com/bohwaz/42fc223031e2b2dd2585aab159a20f30 (for the original code).
  */
 function qxtranxf_intl_strftime( $format, $timestamp = null, $locale = null ) {
@@ -199,16 +199,16 @@ function qxtranxf_intl_strftime( $format, $timestamp = null, $locale = null ) {
 }
 
 /**
- * [Legacy] Converter of a format given in DateTime format, transformed to the extended "QTX-strftime" format.
+ * Converter of a format given in DateTime format, transformed to the extended "QTX-strftime" format.
  *
  * @param string $format in DateTime format.
  *
  * @return string
- * @deprecated Don't use strftime formats anymore, since strftime is deprecated from PHP8.1.
+ * @todo Maybe deprecate. Don't use strftime formats anymore, since strftime is deprecated from PHP8.1.
  * @see https://www.php.net/manual/en/function.strftime.php
  * @see https://www.php.net/manual/en/datetime.format.php
  */
-function qtranxf_convertDateFormatToStrftimeFormat( $format ) {
+function qtranxf_convert_date_format_to_strftime_format( $format ) {
     $mappings = array(
         // day
         'd' => '%d',
@@ -275,6 +275,19 @@ function qtranxf_convertDateFormatToStrftimeFormat( $format ) {
 }
 
 /**
+ * [Legacy] Converter of a format given in DateTime format, transformed to the extended "QTX-strftime" format.
+ *
+ * @param string $format in DateTime format.
+ *
+ * @return string
+ * @deprecated Use qtranxf_convert_date_format_to_strftime_format.
+ */
+function qtranxf_convertDateFormatToStrftimeFormat( $format ) {
+    _deprecated_function( __FUNCTION__, '3.13.0', 'qtranxf_convert_date_format_to_strftime_format' );
+    return qtranxf_convert_date_format_to_strftime_format( $format );
+}
+
+/**
  * [Legacy] Converter of a format/default pair to "QTX-strftime" format, applying 'use_strftime' configuration.
  *
  * @param string $format
@@ -291,7 +304,7 @@ function qtranxf_convertFormat( $format, $default_format ) {
         case 'c':
         case 'r':
         case 'U':
-            return qtranxf_convertDateFormatToStrftimeFormat( $format );
+            return qtranxf_convert_date_format_to_strftime_format( $format );
         default:
             break;
     }
@@ -300,9 +313,9 @@ function qtranxf_convertFormat( $format, $default_format ) {
             if ( empty( $format ) ) {
                 $format = $default_format;
             }
-            return qtranxf_convertDateFormatToStrftimeFormat( $format );
+            return qtranxf_convert_date_format_to_strftime_format( $format );
         case QTX_DATE_OVERRIDE:
-            return qtranxf_convertDateFormatToStrftimeFormat( $default_format );
+            return qtranxf_convert_date_format_to_strftime_format( $default_format );
         case QTX_STRFTIME:
             return $format;
         case QTX_STRFTIME_OVERRIDE:
@@ -456,7 +469,7 @@ function qtranxf_format_date_time( $format, $language_format, $mysql_date_time, 
     }
     // TODO: abandon strftime format in qTranslate.
     if ( ! empty( $format ) && $q_config['use_strftime'] == QTX_STRFTIME ) {
-        $format = qtranxf_convertDateFormatToStrftimeFormat( $format );
+        $format = qtranxf_convert_date_format_to_strftime_format( $format );
     }
     $date_format = qtranxf_convertFormat( $format, $language_format );
     return empty( $date_format ) ? $default_value : qxtranxf_intl_strftime( $date_format, $timestamp, get_locale() );

--- a/qtranslate_date_time.php
+++ b/qtranslate_date_time.php
@@ -17,7 +17,7 @@
  * @param integer|string|DateTime $timestamp Timestamp
  *
  * @return string
- * @deprecated Don't use this function, only meant for transition from legacy strftime formats.
+ * @deprecated Avoid using this function, meant to transition from legacy strftime formats - might be removed.
  * @see https://gist.github.com/bohwaz/42fc223031e2b2dd2585aab159a20f30 (for the original code).
  */
 function qxtranxf_intl_strftime( $format, $timestamp = null, $locale = null ) {
@@ -371,13 +371,10 @@ function qtranxf_convertTimeFormat( $format ) {
  * @See https://www.php.net/manual/en/function.strftime.php
  */
 function qtranxf_strftime( $format, $date, $default = '', $before = '', $after = '' ) {
+    _deprecated_function( __FUNCTION__, '3.13.0', 'qxtranxf_intl_strftime' );
+
     if ( empty( $format ) ) {
         return $default;
-    }
-
-    // Workaround for legacy strftime formats, using IntlDateFormatter instead.
-    if ( version_compare( PHP_VERSION, '8.1' ) >= 0 ) {
-        return qxtranxf_intl_strftime( $format, $date, get_locale() );
     }
 
     // add date suffix ability (%q) to strftime
@@ -464,7 +461,10 @@ function qtranxf_format_date( $format, $mysq_time, $default, $before = '', $afte
         $format = qtranxf_convertDateFormatToStrftimeFormat( $format );
     }
 
-    return qtranxf_strftime( qtranxf_convertDateFormat( $format ), $ts, $default, $before, $after );
+    $date_format = qtranxf_convertDateFormat( $format );  // strftime format for a date value
+    $date_output = empty( $date_format ) ? $default : qxtranxf_intl_strftime( $date_format, $ts, get_locale() );
+
+    return $before . $date_output . $after;
 }
 
 /**
@@ -491,7 +491,10 @@ function qtranxf_format_time( $format, $mysq_time, $default, $before = '', $afte
         $format = qtranxf_convertDateFormatToStrftimeFormat( $format );
     }
 
-    return qtranxf_strftime( qtranxf_convertTimeFormat( $format ), $ts, $default, $before, $after );
+    $time_format = qtranxf_convertTimeFormat( $format ); // strftime format for a time value
+    $time_output = empty( $time_format ) ? $default : qxtranxf_intl_strftime( $time_format, $ts, get_locale() );
+
+    return $before . $time_output . $after;
 }
 
 // @see get_the_date

--- a/qtranslate_date_time.php
+++ b/qtranslate_date_time.php
@@ -295,9 +295,6 @@ function qtranxf_convertFormat( $format, $default_format ) {
         default:
             break;
     }
-    // check for multilang formats
-    $format         = qtranxf_useCurrentLanguageIfNotFoundUseDefaultLanguage( $format );
-    $default_format = qtranxf_useCurrentLanguageIfNotFoundUseDefaultLanguage( $default_format );
     switch ( $q_config['use_strftime'] ) {
         case QTX_DATE:
             if ( empty( $format ) ) {
@@ -444,7 +441,7 @@ function qtranxf_strftime( $format, $date, $default = '', $before = '', $after =
 /**
  * [Legacy] Generalized formatting of a date, applying qTranslate 'use_strftime' config.
  *
- * @param string $format the requested user format.
+ * @param string $format the requested user format, in PHP date format.
  * @param string $language_format the language date or time format, used by default or for configuration override.
  * @param string $mysql_date_time date/time string in MySQL format.
  * @param string $default_value default result in case the format conversion fails.
@@ -458,7 +455,6 @@ function qtranxf_format_date_time( $format, $language_format, $mysql_date_time, 
         return $timestamp;
     }
     // TODO: abandon strftime format in qTranslate.
-    $format = qtranxf_useCurrentLanguageIfNotFoundUseDefaultLanguage( $format );
     if ( ! empty( $format ) && $q_config['use_strftime'] == QTX_STRFTIME ) {
         $format = qtranxf_convertDateFormatToStrftimeFormat( $format );
     }


### PR DESCRIPTION
The `strftime` function is deprecated in PHP8.1.
Generalize usage of `qtranxf_intl_strftime` for any PHP version. The old implementation is condemned so no point to maintain it. Eventually the strftime may disappear but this requires more work.

Abandon support of ML date-time formats.
The use case is very unclear and looks like very old legacy code. Simplify the code by assuming the format is only for the current lang.

Bump minimal PHP version to 5.5.
Required by `\DateTimeInterface`. Update composer with `ext-int` for `\IntlDateFormatter`.

Deprecations -> new versions
- `qtranxf_strftime` -> `qtranxf_intl_strftime`
- `qtranxf_convertFormat` -> `qtranxf_convert_to_strftime_format_using_config`. 
- `qtranxf_convertTimeFormat` -> `qtranxf_get_language_config_date_time`.
- `qtranxf_convertDateFormat` -> `qtranxf_get_language_config_date_time`.
-  `qtranxf_convertDateFormatToStrftimeFormat` -> `qtranxf_convert_date_format_to_strftime_format`.
- deprecate `$before` and `$after` arguments in `qtranxf_format_date` and `qtranxf_format_time`