### PR TITLE
Deprecate date/strftime "override" options

### DIFF
--- a/admin/css/qtranslate_configuration.css
+++ b/admin/css/qtranslate_configuration.css
@@ -55,7 +55,10 @@
 }
 
 .qtranxs-deprecated {
-    font-weight: bold;
+    opacity: 0.7;
+}
+
+.qtranxs-deprecated-warning {
     color: darkorange;
 }
 

--- a/admin/qtx_admin.php
+++ b/admin/qtx_admin.php
@@ -145,13 +145,21 @@ function qtranxf_admin_init() {
 
     if ( current_user_can( 'manage_options' ) ) {
         add_action( 'admin_notices', 'qtranxf_admin_notices_config' );
-    }
 
-    if ( current_user_can( 'manage_options' ) && qtranxf_admin_is_config_page()
-        // TODO run this only if one of the forms or actions submitted --> && !empty($_POST)
-    ) {
-        require_once( QTRANSLATE_DIR . '/admin/qtx_admin_options_update.php' );
-        qtranxf_edit_config();
+        if ( qtranxf_admin_is_config_page() ) {
+            // TODO run this only if one of the forms or actions submitted --> && !empty($_POST)
+            require_once( QTRANSLATE_DIR . '/admin/qtx_admin_options_update.php' );
+            qtranxf_edit_config();
+        }
+
+        // Check for deprecated options.
+        if ( isset( $q_config['use_strftime'] ) && ( $q_config['use_strftime'] ) == QTX_STRFTIME_OVERRIDE || $q_config['use_strftime'] == QTX_DATE_OVERRIDE ) {
+            $options_link = admin_url( 'options-general.php?page=qtranslate-xt#advanced' );
+            $options_desc = __( 'advanced settings', 'qtranslate' );
+            $warning      = sprintf( __( 'The value set for option "%s" is deprecated, it will not be supported in the future. Go to the <a href="%s">%s</a> to update it.', 'qtranslate' ),
+                __( 'Date / Time Conversion', 'qtranslate' ), $options_link, $options_desc );
+            qtranxf_add_warning( $warning );
+        }
     }
 
     $next_thanks = get_option( 'qtranslate_next_thanks' );

--- a/admin/qtx_admin_settings.php
+++ b/admin/qtx_admin_settings.php
@@ -561,17 +561,19 @@ class QTX_Admin_Settings {
                         <input type="radio" name="use_strftime"
                                value="<?php echo QTX_DATE; ?>" <?php checked( $q_config['use_strftime'], QTX_DATE ) ?>/> <?php _e( 'Use emulated date function.', 'qtranslate' ) ?>
                     </label><br/>
-                    <label>
+                    <label class="<?php echo( ( $q_config['use_strftime'] == QTX_DATE_OVERRIDE ) ? "qtranxs-deprecated-warning" : "qtranxs-deprecated" ) ?>">
                         <input type="radio" name="use_strftime"
                                value="<?php echo QTX_DATE_OVERRIDE; ?>" <?php checked( $q_config['use_strftime'], QTX_DATE_OVERRIDE ) ?>/> <?php _e( 'Use emulated date function and replace formats with the predefined formats for each language.', 'qtranslate' ) ?>
+                        <span><?php _e( 'Deprecated.', 'qtranslate' ); ?></span>
                     </label><br/>
                     <label>
                         <input type="radio" name="use_strftime"
                                value="<?php echo QTX_STRFTIME; ?>" <?php checked( $q_config['use_strftime'], QTX_STRFTIME ) ?>/> <?php _e( 'Use strftime instead of date.', 'qtranslate' ) ?>
                     </label><br/>
-                    <label>
+                    <label class="<?php echo( ( $q_config['use_strftime'] == QTX_STRFTIME_OVERRIDE ) ? "qtranxs-deprecated-warning" : "qtranxs-deprecated" ) ?>">
                         <input type="radio" name="use_strftime"
                                value="<?php echo QTX_STRFTIME_OVERRIDE; ?>" <?php checked( $q_config['use_strftime'], QTX_STRFTIME_OVERRIDE ) ?>/> <?php _e( 'Use strftime instead of date and replace formats with the predefined formats for each language.', 'qtranslate' ) ?>
+                        <span><?php _e( 'Deprecated.', 'qtranslate' ); ?></span>
                     </label>
                     <p class="qtranxs-notes"><?php _e( 'Depending on the mode selected, additional customizations of the theme may be needed.', 'qtranslate' ) ?></p>
                 </td>
@@ -782,12 +784,11 @@ class QTX_Admin_Settings {
                 </td>
             </tr>
             <tr>
-                <th scope="row"><?php _e( 'Custom Configuration', 'qtranslate' ) ?></th>
+                <th scope="row"><?php _e( 'Custom Configuration', 'qtranslate' ); ?></th>
                 <td><label for="qtranxs_json_custom_i18n_config"
-                           class="qtranxs_explanation"><?php
-                        if ( ! empty( $q_config['custom_i18n_config'] ) ) {
-                            echo( '<p class="qtranxs-deprecated">' . __( 'Deprecated', 'qtranslate' ) . '</p>' );
-                        }
+                           class="qtranxs_explanation <?php echo( empty( $q_config['custom_i18n_config'] ) ? "qtranxs-deprecated" : "qtranxs-deprecated-warning" ) ?>"><?php
+                        _e( 'Deprecated.', 'qtranslate' );
+                        echo( '<br/>' );
                         printf( __( 'Additional custom JSON-encoded configuration of %s for all admin pages. It is processed after all files from option "%s" are loaded, providing opportunity to add or to override configuration tokens as necessary.', 'qtranslate' ), 'qTranslate&#8209;XT', __( 'Configuration Files', 'qtranslate' ) ); ?></label>
                     <br/><textarea name="json_custom_i18n_config" id="qtranxs_json_custom_i18n_config"
                                    rows="4"

--- a/qtranslate_options.php
+++ b/qtranslate_options.php
@@ -22,12 +22,12 @@ define( 'QTX_URL_DOMAIN', 3 );
 // domain per language
 define( 'QTX_URL_DOMAINS', 4 );
 
-define( 'QTX_DATE_WP', 0 );// default
-// strftime usage (backward compability)
-define( 'QTX_STRFTIME_OVERRIDE', 1 );
-define( 'QTX_DATE_OVERRIDE', 2 );
-define( 'QTX_DATE', 3 );// old default
-define( 'QTX_STRFTIME', 4 );
+// Date/time conversion -> "use_strftime" option
+define( 'QTX_DATE_WP', 0 );
+define( 'QTX_STRFTIME_OVERRIDE', 1 ); // TODO: deprecate strftime format
+define( 'QTX_DATE_OVERRIDE', 2 ); // deprecated
+define( 'QTX_DATE', 3 ); // default format at first activation - not consistent with default date/time values
+define( 'QTX_STRFTIME', 4 ); // deprecated
 
 define( 'QTX_FILTER_OPTIONS_ALL', 0 );
 define( 'QTX_FILTER_OPTIONS_LIST', 1 );
@@ -85,7 +85,7 @@ function qtranxf_set_default_options( &$ops ) {
 
     $ops['front']['int'] = array(
         'url_mode'            => QTX_URL_PATH,  // sets default url mode
-        'use_strftime'        => QTX_DATE,  // strftime usage (backward compability)
+        'use_strftime'        => QTX_DATE,  // strftime usage (backward compatibility)
         'filter_options_mode' => QTX_FILTER_OPTIONS_ALL,
         'language_name_case'  => 0  //Camel Case
     );
@@ -297,6 +297,7 @@ function qtranxf_default_not_available() {
 
 /**
  * Date Configuration
+ * @todo Deprecate strftime format
  * @since 3.3
  */
 function qtranxf_default_date_format() {
@@ -342,6 +343,7 @@ function qtranxf_default_date_format() {
 
 /**
  * Time Configuration
+ * @todo Deprecate strftime format
  * @since 3.3
  */
 function qtranxf_default_time_format() {


### PR DESCRIPTION
Relates to #1234.

The "override" date/time options are too confusing. If a user ask for a specific format it should never be overriden. The use case would only be for debug, but not for the end-user. We might add new options to disable the translation or replace the current language format with a default value, but that is out of scope for the current "override" values.

Improve the CSS styles for deprecated options with two levels.