### PR TITLE
Add date/time option to use WP and ignore QTX formats

### DIFF
--- a/admin/qtx_admin_settings.php
+++ b/admin/qtx_admin_settings.php
@@ -559,6 +559,10 @@ class QTX_Admin_Settings {
                 <td>
                     <label>
                         <input type="radio" name="use_strftime"
+                               value="<?php echo QTX_DATE_WP; ?>" <?php checked( $q_config['use_strftime'], QTX_DATE_WP ) ?>/> <?php _e( 'Use WordPress options and translation. Ignore language date / time formats.', 'qtranslate' ) ?>
+                    </label><br/>
+                    <label>
+                        <input type="radio" name="use_strftime"
                                value="<?php echo QTX_DATE; ?>" <?php checked( $q_config['use_strftime'], QTX_DATE ) ?>/> <?php _e( 'Use emulated date function.', 'qtranslate' ) ?>
                     </label><br/>
                     <label class="<?php echo( ( $q_config['use_strftime'] == QTX_DATE_OVERRIDE ) ? "qtranxs-deprecated-warning" : "qtranxs-deprecated" ) ?>">

--- a/qtranslate_date_time.php
+++ b/qtranslate_date_time.php
@@ -316,6 +316,7 @@ function qtranxf_convert_to_strftime_format_using_config( $format, $default_form
             return ( ! empty( $format ) ? qtranxf_convert_date_format_to_strftime_format( $format ) : stripslashes( $default_format ) );
         case QTX_STRFTIME_OVERRIDE:
             return stripslashes( $default_format );
+        case QTX_DATE_WP:
         default:
             return '';
     }

--- a/qtranslate_hooks.php
+++ b/qtranslate_hooks.php
@@ -123,6 +123,8 @@ function qtranxf_ngettext( $translated_text ) {
  * @return void
  */
 function qtranxf_add_main_filters() {
+    global $q_config;
+
     // Hooks defined differently in admin and frontend
     add_filter( 'wp_trim_words', 'qtranxf_trim_words', 0, 4 );
 
@@ -138,12 +140,14 @@ function qtranxf_add_main_filters() {
     add_filter( 'the_excerpt', 'qtranxf_useCurrentLanguageIfNotFoundShowAvailable', 0 );
     add_filter( 'the_excerpt_rss', 'qtranxf_useCurrentLanguageIfNotFoundShowAvailable', 0 );
 
-    add_filter( 'get_comment_date', 'qtranxf_dateFromCommentForCurrentLanguage', 0, 3 );
-    add_filter( 'get_comment_time', 'qtranxf_timeFromCommentForCurrentLanguage', 0, 5 );
-    add_filter( 'get_post_modified_time', 'qtranxf_timeModifiedFromPostForCurrentLanguage', 0, 3 );
-    add_filter( 'get_the_time', 'qtranxf_timeFromPostForCurrentLanguage', 0, 3 );
-    add_filter( 'get_the_date', 'qtranxf_dateFromPostForCurrentLanguage', 0, 3 );
-    add_filter( 'get_the_modified_date', 'qtranxf_dateModifiedFromPostForCurrentLanguage', 0, 2 );
+    if ( $q_config['use_strftime'] != QTX_DATE_WP ) {
+        add_filter( 'get_comment_date', 'qtranxf_dateFromCommentForCurrentLanguage', 0, 3 );
+        add_filter( 'get_comment_time', 'qtranxf_timeFromCommentForCurrentLanguage', 0, 5 );
+        add_filter( 'get_post_modified_time', 'qtranxf_timeModifiedFromPostForCurrentLanguage', 0, 3 );
+        add_filter( 'get_the_time', 'qtranxf_timeFromPostForCurrentLanguage', 0, 3 );
+        add_filter( 'get_the_date', 'qtranxf_dateFromPostForCurrentLanguage', 0, 3 );
+        add_filter( 'get_the_modified_date', 'qtranxf_dateModifiedFromPostForCurrentLanguage', 0, 2 );
+    }
 
     add_filter( 'locale', 'qtranxf_localeForCurrentLanguage', 99 );
     add_filter( 'core_version_check_locale', 'qtranxf_versionLocale' );

--- a/qtranslate_options.php
+++ b/qtranslate_options.php
@@ -28,7 +28,7 @@ const QTX_URL_DOMAINS = 4;  // Domain per language
 /**
  * Date/time conversion, see "use_strftime" option.
  */
-const QTX_DATE_WP           = 0;  // obsolete, value reserved
+const QTX_DATE_WP           = 0;  // Use WordPress options and translation, disable all date / time hooks.
 const QTX_STRFTIME_OVERRIDE = 1;  // TODO: deprecate strftime format
 const QTX_DATE_OVERRIDE     = 2;  // deprecated
 const QTX_DATE              = 3;  // default format at first activation - not consistent with default date/time values


### PR DESCRIPTION
The `strftime` function is deprecated in PHP8.1 but the legacy language formats are still maintained with `IntlDateFormatter` (#1228, #1238). The strftime format used in the qTranslate language options should be deprecated (#1234). The date format should also be refactored without intermediate legacy conversions.

Meanwhile, it is safer to add a fallback option to disable any date/time conversion and hooks in qTranslate in case something unexpected would happen. This option could be enough for some users. The standard WP behavior for `the_time()` and all filters with `get_post_modified_time` is translating the global date/time WP formats. However when calling functions like `get_post_time()` from the code without any argument, no translation is done which could be unexpected when using qTranslate. Also, the WP options only allow to define a format for date and another for time, which could also be too restrictive.