### PR TITLE
Deprecate ACF-qTranslate `text/textarea/wysiwyg` extended fields

### DIFF
--- a/src/modules/acf/admin.php
+++ b/src/modules/acf/admin.php
@@ -282,13 +282,13 @@ class QTX_Module_Acf_Admin {
             'section-acf-extended',
             __( 'Extended qTranslate fields', 'qtranslate' ),
             function () {
-                _e( 'Additional types with a specific handling and rendering for qTranslate. Prefer the standard ACF fields as much as possible.', 'qtranslate' );
+                _e( 'Additional types specific to qTranslate. Prefer the standard ACF fields.', 'qtranslate' );
             },
             'settings-qtranslate-acf'
         );
         add_settings_field(
             'select_qtranslate_fields',
-            __( 'Active types', 'qtranslate' ),
+            __( 'Types enabled for selection', 'qtranslate' ),
             array( $this, 'render_setting_qtranslate_fields' ),
             'settings-qtranslate-acf',
             'section-acf-extended'

--- a/src/modules/acf/fields/text.php
+++ b/src/modules/acf/fields/text.php
@@ -28,7 +28,7 @@ class QTX_Module_Acf_Field_Text extends acf_field_text {
         parent::initialize();
         $this->name     = 'qtranslate_text';
         $this->category = QTX_Module_Acf_Register::ACF_CATEGORY_QTX;
-        $this->label .= ' [' . $this->category . ']';
+        $this->label    .= ' [' . $this->category . ']' . ' - ' . __( 'Deprecated', 'qtranslate' );
     }
 
     /**

--- a/src/modules/acf/fields/textarea.php
+++ b/src/modules/acf/fields/textarea.php
@@ -28,7 +28,7 @@ class QTX_Module_Acf_Field_Textarea extends acf_field_textarea {
         parent::initialize();
         $this->name     = 'qtranslate_textarea';
         $this->category = QTX_Module_Acf_Register::ACF_CATEGORY_QTX;
-        $this->label    .= ' [' . $this->category . ']';
+        $this->label    .= ' [' . $this->category . ']' . ' - ' . __( 'Deprecated', 'qtranslate' );
     }
 
     /**

--- a/src/modules/acf/fields/wysiwyg.php
+++ b/src/modules/acf/fields/wysiwyg.php
@@ -28,7 +28,7 @@ class QTX_Module_Acf_Field_Wysiwyg extends acf_field_wysiwyg {
         parent::initialize();
         $this->name     = 'qtranslate_wysiwyg';
         $this->category = QTX_Module_Acf_Register::ACF_CATEGORY_QTX;
-        $this->label    .= ' [' . $this->category . ']';
+        $this->label    .= ' [' . $this->category . ']' . ' - ' . __( 'Deprecated', 'qtranslate' );
     }
 
     /**


### PR DESCRIPTION
Follow-up of #1186 and #1300.
Since the standard ACF fields are better supported, those should be preferred over the qTranslate extended fields.

In particular: `text`, `textarea`, `wysiwyg` are covered by the ACF standard fields, while others only exist as qTranslate extended fields.

Deprecate softly these "duplicated" extended fields in their labels.