### PR TITLE
Bump ACF minimal version 5.6.0

### DIFF
--- a/src/modules/acf/admin.php
+++ b/src/modules/acf/admin.php
@@ -66,7 +66,7 @@ class QTX_Module_Acf_Admin {
      * @return array
      */
     public function get_field_types( $groups ) {
-        if ( ! isset ( $groups[ QTX_Module_Acf_Register::ACF_CATEGORY_QTX ] ) ) {
+        if ( ! isset ( $groups[ QTX_Module_Acf_Extended::ACF_CATEGORY_QTX ] ) ) {
             return $groups;
         }
         $fields    = array_keys( self::qtranslate_fields() );
@@ -75,14 +75,14 @@ class QTX_Module_Acf_Admin {
         $is_active = function ( $field ) use ( $settings ) {
             return isset( $settings[ $field ] ) && $settings[ $field ];
         };
-        $group_qtx = &$groups[ QTX_Module_Acf_Register::ACF_CATEGORY_QTX ];
+        $group_qtx = &$groups[ QTX_Module_Acf_Extended::ACF_CATEGORY_QTX ];
         foreach ( $group_qtx as $field_id => $field_object ) {
             if ( ! $is_active( $field_id ) ) {
                 unset( $group_qtx[ $field_id ] );
             }
         }
         if ( empty( $group_qtx ) ) {
-            unset( $groups[ QTX_Module_Acf_Register::ACF_CATEGORY_QTX ] );
+            unset( $groups[ QTX_Module_Acf_Extended::ACF_CATEGORY_QTX ] );
         }
         return $groups;
     }

--- a/src/modules/acf/extended.php
+++ b/src/modules/acf/extended.php
@@ -1,9 +1,9 @@
 <?php
 
 /**
- * Allows the integration with ACF by setting up the derived fields.
+ * Allows the integration with ACF by setting up the `qTranslate` extended fields.
  */
-class QTX_Module_Acf_Register {
+class QTX_Module_Acf_Extended {
     /**
      * @var string ACF category ID for the qTranslate extended fields.
      */
@@ -30,16 +30,13 @@ class QTX_Module_Acf_Register {
         require_once __DIR__ . '/fields/url.php';
         require_once __DIR__ . '/fields/wysiwyg.php';
 
-        // Before ACF 5.6.0 initialize() must be called explicitly in the constructors of the acf_field derived classes.
-        $do_initialize = version_compare( acf()->settings['version'], '5.6.0' ) < 0;
-
-        acf()->fields->register_field_type( new QTX_Module_Acf_Field_File( $this, $do_initialize ) );
-        acf()->fields->register_field_type( new QTX_Module_Acf_Field_Image( $this, $do_initialize ) );
-        acf()->fields->register_field_type( new QTX_Module_Acf_Field_Post_Object( $this, $do_initialize ) );
-        acf()->fields->register_field_type( new QTX_Module_Acf_Field_Text( $this, $do_initialize ) );
-        acf()->fields->register_field_type( new QTX_Module_Acf_Field_Textarea( $this, $do_initialize ) );
-        acf()->fields->register_field_type( new QTX_Module_Acf_Field_Url( $this, $do_initialize ) );
-        acf()->fields->register_field_type( new QTX_Module_Acf_Field_Wysiwyg( $this, $do_initialize ) );
+        acf()->fields->register_field_type( new QTX_Module_Acf_Field_File() );
+        acf()->fields->register_field_type( new QTX_Module_Acf_Field_Image() );
+        acf()->fields->register_field_type( new QTX_Module_Acf_Field_Post_Object() );
+        acf()->fields->register_field_type( new QTX_Module_Acf_Field_Text() );
+        acf()->fields->register_field_type( new QTX_Module_Acf_Field_Textarea() );
+        acf()->fields->register_field_type( new QTX_Module_Acf_Field_Url() );
+        acf()->fields->register_field_type( new QTX_Module_Acf_Field_Wysiwyg() );
     }
 
     /**
@@ -68,7 +65,7 @@ class QTX_Module_Acf_Register {
      *
      * @return string
      */
-    public function encode_language_values( $values ) {
+    public static function encode_language_values( $values ) {
         assert( is_array( $values ) );
 
         return qtranxf_join_b( $values );
@@ -81,7 +78,7 @@ class QTX_Module_Acf_Register {
      *
      * @return array
      */
-    public function decode_language_values( $values ) {
+    public static function decode_language_values( $values ) {
         return qtranxf_split( $values );
     }
 
@@ -95,13 +92,13 @@ class QTX_Module_Acf_Register {
      * @param object $field_object corresponding to the qtranslate ACF field item
      * @param bool|string $valid
      * @param array $values holding a string value per language
-     * @param string $field
+     * @param array $field info
      * @param string $input
      *
      * @return    bool|string
      * @see acf_validation::acf_validate_value
      */
-    public function validate_language_values( $field_object, $valid, $values, $field, $input ) {
+    public static function validate_language_values( $field_object, $valid, $values, $field, $input ) {
         global $q_config;
 
         // retrieve the original ACF validation method for that field (cumbersome, but we can't change acf_field base class)
@@ -118,16 +115,22 @@ class QTX_Module_Acf_Register {
         foreach ( $values as $key_language => $value_language ) {
             // validate properly the required value (see: acf_validate_value in acf_validation)
             if ( $field['required'] && empty( $value_language ) ) {
-                return '(' . $q_config['language_name'][ $key_language ] . ') ' . sprintf( __( '%s value is required', 'acf' ), $field['label'] );
+                // TODO: retrieve the label for the language being edited.
+                $label = qtranxf_useCurrentLanguageIfNotFoundUseDefaultLanguage( $field['label'] );
+                return '(' . $q_config['language_name'][ $key_language ] . ') ' . sprintf( __( '%s value is required', 'acf' ), $label );
             }
             // validate with original ACF method
             if ( isset( $validation_method ) ) {
-                $valid_language = $validation_method->invokeArgs( $field_object, array(
-                    $valid,
-                    $value_language,
-                    $field,
-                    $input
-                ) );
+                try {
+                    $valid_language = $validation_method->invokeArgs( $field_object, array(
+                        $valid,
+                        $value_language,
+                        $field,
+                        $input
+                    ) );
+                } catch ( ReflectionException $exception ) {
+                    return $exception->getMessage();
+                }
                 if ( ! empty( $valid_language ) && is_string( $valid_language ) ) {
                     return '(' . $q_config['language_name'][ $key_language ] . ') ' . $valid_language;
                 }

--- a/src/modules/acf/fields/file.php
+++ b/src/modules/acf/fields/file.php
@@ -2,32 +2,12 @@
 
 class QTX_Module_Acf_Field_File extends acf_field_file {
     /**
-     * The register instance
-     * @var QTX_Module_Acf_Register
-     */
-    protected $register;
-
-    /**
-     * Constructor
-     *
-     * @param QTX_Module_Acf_Register $register
-     * @param bool $do_initialize true if initialize() must be called explicitly
-     */
-    function __construct( $register, $do_initialize ) {
-        $this->register = $register;
-        if ( $do_initialize ) {
-            $this->initialize();
-        }
-        parent::__construct();
-    }
-
-    /**
      * Setup the field type data
      */
     function initialize() {
         parent::initialize();
         $this->name     = 'qtranslate_file';
-        $this->category = QTX_Module_Acf_Register::ACF_CATEGORY_QTX;
+        $this->category = QTX_Module_Acf_Extended::ACF_CATEGORY_QTX;
         $this->label    .= ' [' . $this->category . ']';
     }
 
@@ -40,7 +20,7 @@ class QTX_Module_Acf_Field_File extends acf_field_file {
         global $q_config;
 
         $languages       = qtranxf_getSortedLanguages( true );
-        $values          = $this->register->decode_language_values( $field['value'] );
+        $values          = QTX_Module_Acf_Extended::decode_language_values( $field['value'] );
         $currentLanguage = qtranxf_getLanguage();
 
         $uploader = acf_get_setting( 'uploader' );
@@ -193,7 +173,7 @@ class QTX_Module_Acf_Field_File extends acf_field_file {
             }
         }
 
-        return $this->register->encode_language_values( $values );
+        return QTX_Module_Acf_Extended::encode_language_values( $values );
     }
 
     /**
@@ -209,7 +189,7 @@ class QTX_Module_Acf_Field_File extends acf_field_file {
      */
     function validate_value( $valid, $value, $field, $input ) {
         if ( is_array( $value ) ) {
-            $valid = $this->register->validate_language_values( $this, $valid, $value, $field, $input );
+            $valid = QTX_Module_Acf_Extended::validate_language_values( $this, $valid, $value, $field, $input );
         }
 
         return $valid;

--- a/src/modules/acf/fields/image.php
+++ b/src/modules/acf/fields/image.php
@@ -2,32 +2,12 @@
 
 class QTX_Module_Acf_Field_Image extends acf_field_image {
     /**
-     * The register instance
-     * @var QTX_Module_Acf_Register
-     */
-    protected $register;
-
-    /**
-     * Constructor
-     *
-     * @param QTX_Module_Acf_Register $register
-     * @param bool $do_initialize true if initialize() must be called explicitly
-     */
-    function __construct( $register, $do_initialize ) {
-        $this->register = $register;
-        if ( $do_initialize ) {
-            $this->initialize();
-        }
-        parent::__construct();
-    }
-
-    /**
      *  Setup the field type data
      */
     function initialize() {
         parent::initialize();
         $this->name     = 'qtranslate_image';
-        $this->category = QTX_Module_Acf_Register::ACF_CATEGORY_QTX;
+        $this->category = QTX_Module_Acf_Extended::ACF_CATEGORY_QTX;
         $this->label    .= ' [' . $this->category . ']';
     }
 
@@ -40,7 +20,7 @@ class QTX_Module_Acf_Field_Image extends acf_field_image {
         global $q_config;
 
         $languages       = qtranxf_getSortedLanguages( true );
-        $values          = $this->register->decode_language_values( $field['value'] );
+        $values          = QTX_Module_Acf_Extended::decode_language_values( $field['value'] );
         $currentLanguage = qtranxf_getLanguage();
 
         $field_name = $field['name'];

--- a/src/modules/acf/fields/post_object.php
+++ b/src/modules/acf/fields/post_object.php
@@ -2,32 +2,12 @@
 
 class QTX_Module_Acf_Field_Post_Object extends acf_field_post_object {
     /**
-     * The register instance
-     * @var QTX_Module_Acf_Register
-     */
-    protected $register;
-
-    /**
-     * Constructor
-     *
-     * @param QTX_Module_Acf_Register $register
-     * @param bool $do_initialize true if initialize() must be called explicitly
-     */
-    function __construct( $register, $do_initialize ) {
-        $this->register = $register;
-        if ( $do_initialize ) {
-            $this->initialize();
-        }
-        parent::__construct();
-    }
-
-    /**
      *  Setup the field type data
      */
     function initialize() {
         parent::initialize();
         $this->name     = 'qtranslate_post_object';
-        $this->category = QTX_Module_Acf_Register::ACF_CATEGORY_QTX;
+        $this->category = QTX_Module_Acf_Extended::ACF_CATEGORY_QTX;
         $this->label    .= ' [' . $this->category . ']';
     }
 
@@ -39,7 +19,7 @@ class QTX_Module_Acf_Field_Post_Object extends acf_field_post_object {
     function render_field( $field ) {
         global $q_config;
         $languages       = qtranxf_getSortedLanguages( true );
-        $decoded         = $this->register->decode_language_values( $field['value'] );
+        $decoded         = QTX_Module_Acf_Extended::decode_language_values( $field['value'] );
         $values          = array_map( 'maybe_unserialize', $decoded );
         $currentLanguage = qtranxf_getLanguage();
 
@@ -114,7 +94,7 @@ class QTX_Module_Acf_Field_Post_Object extends acf_field_post_object {
             $value = maybe_serialize( $value );
         }
 
-        return $this->register->encode_language_values( $values );
+        return QTX_Module_Acf_Extended::encode_language_values( $values );
     }
 
     /**
@@ -130,7 +110,7 @@ class QTX_Module_Acf_Field_Post_Object extends acf_field_post_object {
      */
     function validate_value( $valid, $value, $field, $input ) {
         if ( is_array( $value ) ) {
-            $valid = $this->register->validate_language_values( $this, $valid, $value, $field, $input );
+            $valid = QTX_Module_Acf_Extended::validate_language_values( $this, $valid, $value, $field, $input );
         }
 
         return $valid;

--- a/src/modules/acf/fields/text.php
+++ b/src/modules/acf/fields/text.php
@@ -2,32 +2,12 @@
 
 class QTX_Module_Acf_Field_Text extends acf_field_text {
     /**
-     * The register instance
-     * @var QTX_Module_Acf_Register
-     */
-    protected $register;
-
-    /**
-     * Constructor
-     *
-     * @param QTX_Module_Acf_Register $register
-     * @param bool $do_initialize true if initialize() must be called explicitly
-     */
-    function __construct( $register, $do_initialize ) {
-        $this->register = $register;
-        if ( $do_initialize ) {
-            $this->initialize();
-        }
-        parent::__construct();
-    }
-
-    /**
      *  Setup the field type data
      */
     function initialize() {
         parent::initialize();
         $this->name     = 'qtranslate_text';
-        $this->category = QTX_Module_Acf_Register::ACF_CATEGORY_QTX;
+        $this->category = QTX_Module_Acf_Extended::ACF_CATEGORY_QTX;
         $this->label    .= ' [' . $this->category . ']' . ' - ' . __( 'Deprecated', 'qtranslate' );
     }
 
@@ -39,7 +19,7 @@ class QTX_Module_Acf_Field_Text extends acf_field_text {
     function render_field( $field ) {
         global $q_config;
         $languages       = qtranxf_getSortedLanguages( true );
-        $values          = $this->register->decode_language_values( $field['value'] );
+        $values          = QTX_Module_Acf_Extended::decode_language_values( $field['value'] );
         $currentLanguage = qtranxf_getLanguage();
 
         $atts = array();
@@ -123,7 +103,7 @@ class QTX_Module_Acf_Field_Text extends acf_field_text {
      * @see acf_field_text::update_value
      */
     function update_value( $values, $post_id, $field ) {
-        return $this->register->encode_language_values( $values );
+        return QTX_Module_Acf_Extended::encode_language_values( $values );
     }
 
     /**
@@ -139,7 +119,7 @@ class QTX_Module_Acf_Field_Text extends acf_field_text {
      */
     function validate_value( $valid, $value, $field, $input ) {
         if ( is_array( $value ) ) {
-            $valid = $this->register->validate_language_values( $this, $valid, $value, $field, $input );
+            $valid = QTX_Module_Acf_Extended::validate_language_values( $this, $valid, $value, $field, $input );
         }
 
         return $valid;

--- a/src/modules/acf/fields/textarea.php
+++ b/src/modules/acf/fields/textarea.php
@@ -2,32 +2,12 @@
 
 class QTX_Module_Acf_Field_Textarea extends acf_field_textarea {
     /**
-     * The register instance
-     * @var QTX_Module_Acf_Register
-     */
-    protected $register;
-
-    /**
-     * Constructor
-     *
-     * @param QTX_Module_Acf_Register $register
-     * @param bool $do_initialize true if initialize() must be called explicitly
-     */
-    function __construct( $register, $do_initialize ) {
-        $this->register = $register;
-        if ( $do_initialize ) {
-            $this->initialize();
-        }
-        parent::__construct();
-    }
-
-    /**
      * Setup the field type data
      */
     function initialize() {
         parent::initialize();
         $this->name     = 'qtranslate_textarea';
-        $this->category = QTX_Module_Acf_Register::ACF_CATEGORY_QTX;
+        $this->category = QTX_Module_Acf_Extended::ACF_CATEGORY_QTX;
         $this->label    .= ' [' . $this->category . ']' . ' - ' . __( 'Deprecated', 'qtranslate' );
     }
 
@@ -39,7 +19,7 @@ class QTX_Module_Acf_Field_Textarea extends acf_field_textarea {
     function render_field( $field ) {
         global $q_config;
         $languages       = qtranxf_getSortedLanguages( true );
-        $values          = $this->register->decode_language_values( $field['value'] );
+        $values          = QTX_Module_Acf_Extended::decode_language_values( $field['value'] );
         $currentLanguage = qtranxf_getLanguage();
 
         if ( empty( $field['rows'] ) ) {
@@ -96,7 +76,7 @@ class QTX_Module_Acf_Field_Textarea extends acf_field_textarea {
      * @see acf_field_textarea::render_field
      */
     function update_value( $values, $post_id, $field ) {
-        return $this->register->encode_language_values( $values );
+        return QTX_Module_Acf_Extended::encode_language_values( $values );
     }
 
     /**
@@ -112,7 +92,7 @@ class QTX_Module_Acf_Field_Textarea extends acf_field_textarea {
      */
     function validate_value( $valid, $value, $field, $input ) {
         if ( is_array( $value ) ) {
-            $valid = $this->register->validate_language_values( $this, $valid, $value, $field, $input );
+            $valid = QTX_Module_Acf_Extended::validate_language_values( $this, $valid, $value, $field, $input );
         }
 
         return $valid;

--- a/src/modules/acf/fields/url.php
+++ b/src/modules/acf/fields/url.php
@@ -2,32 +2,12 @@
 
 class QTX_Module_Acf_Field_Url extends acf_field_url {
     /**
-     * The register instance
-     * @var QTX_Module_Acf_Register
-     */
-    protected $register;
-
-    /**
-     * Constructor
-     *
-     * @param QTX_Module_Acf_Register $register
-     * @param bool $do_initialize true if initialize() must be called explicitly
-     */
-    function __construct( $register, $do_initialize ) {
-        $this->register = $register;
-        if ( $do_initialize ) {
-            $this->initialize();
-        }
-        parent::__construct();
-    }
-
-    /**
      * Setup the field type data
      */
     function initialize() {
         parent::initialize();
         $this->name     = 'qtranslate_url';
-        $this->category = QTX_Module_Acf_Register::ACF_CATEGORY_QTX;
+        $this->category = QTX_Module_Acf_Extended::ACF_CATEGORY_QTX;
         $this->label    .= ' [' . $this->category . ']';
     }
 
@@ -39,7 +19,7 @@ class QTX_Module_Acf_Field_Url extends acf_field_url {
     function render_field( $field ) {
         global $q_config;
         $languages       = qtranxf_getSortedLanguages( true );
-        $values          = $this->register->decode_language_values( $field['value'] );
+        $values          = QTX_Module_Acf_Extended::decode_language_values( $field['value'] );
         $currentLanguage = qtranxf_getLanguage();
 
         $atts = array();
@@ -97,7 +77,7 @@ class QTX_Module_Acf_Field_Url extends acf_field_url {
      * @return string - the modified value
      */
     function update_value( $values, $post_id, $field ) {
-        return $this->register->encode_language_values( $values );
+        return QTX_Module_Acf_Extended::encode_language_values( $values );
     }
 
     /**
@@ -113,7 +93,7 @@ class QTX_Module_Acf_Field_Url extends acf_field_url {
      */
     function validate_value( $valid, $value, $field, $input ) {
         if ( is_array( $value ) ) {
-            $valid = $this->register->validate_language_values( $this, $valid, $value, $field, $input );
+            $valid = QTX_Module_Acf_Extended::validate_language_values( $this, $valid, $value, $field, $input );
         }
 
         return $valid;

--- a/src/modules/acf/fields/wysiwyg.php
+++ b/src/modules/acf/fields/wysiwyg.php
@@ -2,32 +2,12 @@
 
 class QTX_Module_Acf_Field_Wysiwyg extends acf_field_wysiwyg {
     /**
-     * The register instance
-     * @var QTX_Module_Acf_Register
-     */
-    protected $register;
-
-    /**
-     * Constructor
-     *
-     * @param QTX_Module_Acf_Register $register
-     * @param bool $do_initialize true if initialize() must be called explicitly
-     */
-    function __construct( $register, $do_initialize ) {
-        $this->register = $register;
-        if ( $do_initialize ) {
-            $this->initialize();
-        }
-        parent::__construct();
-    }
-
-    /**
      * Setup the field type data
      */
     function initialize() {
         parent::initialize();
         $this->name     = 'qtranslate_wysiwyg';
-        $this->category = QTX_Module_Acf_Register::ACF_CATEGORY_QTX;
+        $this->category = QTX_Module_Acf_Extended::ACF_CATEGORY_QTX;
         $this->label    .= ' [' . $this->category . ']' . ' - ' . __( 'Deprecated', 'qtranslate' );
     }
 
@@ -79,7 +59,7 @@ class QTX_Module_Acf_Field_Wysiwyg extends acf_field_wysiwyg {
         global $q_config;
 
         $languages       = qtranxf_getSortedLanguages( true );
-        $values          = $this->register->decode_language_values( $field['value'] );
+        $values          = QTX_Module_Acf_Extended::decode_language_values( $field['value'] );
         $currentLanguage = qtranxf_getLanguage();
 
         echo '<div class="multi-language-field multi-language-field-wysiwyg">';
@@ -146,7 +126,7 @@ class QTX_Module_Acf_Field_Wysiwyg extends acf_field_wysiwyg {
      * @return    string - the modified value
      */
     function update_value( $values, $post_id, $field ) {
-        return $this->register->encode_language_values( $values );
+        return QTX_Module_Acf_Extended::encode_language_values( $values );
     }
 
     /**
@@ -162,7 +142,7 @@ class QTX_Module_Acf_Field_Wysiwyg extends acf_field_wysiwyg {
      */
     function validate_value( $valid, $value, $field, $input ) {
         if ( is_array( $value ) ) {
-            $valid = $this->register->validate_language_values( $this, $valid, $value, $field, $input );
+            $valid = QTX_Module_Acf_Extended::validate_language_values( $this, $valid, $value, $field, $input );
         }
 
         return $valid;

--- a/src/modules/acf/loader.php
+++ b/src/modules/acf/loader.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * Setup module if Advanced Custom Fields is enabled and version >= 5.0.0
+ * Setup module if Advanced Custom Fields is enabled and version >= 5.6.0
  *
  * @return void
  */
@@ -14,9 +14,9 @@ function qtranxf_acf_init() {
     static $acf_loaded = false;
 
     if ( ! $acf_loaded && function_exists( 'acf' ) ) {
-        if ( version_compare( acf()->settings['version'], '5.0.0' ) >= 0 ) {
-            require_once __DIR__ . '/register.php';
-            new QTX_Module_Acf_Register();
+        if ( version_compare( acf()->settings['version'], '5.6.0' ) >= 0 ) {
+            require_once __DIR__ . '/extended.php';
+            new QTX_Module_Acf_Extended();
 
             if ( is_admin() ) {
                 require_once __DIR__ . '/admin.php';


### PR DESCRIPTION
ACF before 5.6.0 requires a special handling for `initialize()` methods in extended fields.
Require ACF minimal version 5.6.0 to simplify the code and delete the constructors.
Rename `QTX_Module_Acf_Register` to `QTX_Module_Acf_Extended` and make it mostly static.