### PR TITLE
Add PHP type declarations

### DIFF
--- a/src/admin/activation_hook.php
+++ b/src/admin/activation_hook.php
@@ -13,7 +13,7 @@ require_once QTRANSLATE_DIR . '/src/modules/admin_module_manager.php';
  * @return array
  * @since 3.3
  */
-function qtranxf_save_languages( $cfg ) {
+function qtranxf_save_languages( array $cfg ): array {
     global $qtranslate_options;
     foreach ( $qtranslate_options['languages'] as $key => $option ) {
         if ( is_array( $cfg[ $key ] ) ) {
@@ -36,7 +36,7 @@ function qtranxf_save_languages( $cfg ) {
 /**
  * since 3.2.9.2
  */
-function qtranxf_default_enabled_languages() {
+function qtranxf_default_enabled_languages(): array {
     $locale = get_locale();
     if ( ! $locale ) {
         $locale = 'en_US';
@@ -70,7 +70,7 @@ function qtranxf_default_enabled_languages() {
 /**
  * since 3.2.9.2
  */
-function qtranxf_default_default_language() {
+function qtranxf_default_default_language(): string {
     global $q_config;
     $enabled_languages = qtranxf_default_enabled_languages();
     $default_language  = $enabled_languages[0];
@@ -88,7 +88,7 @@ function qtranxf_default_default_language() {
  * @return array configuration dictionary
  * @since 3.3.2
  */
-function qtranxf_load_config_files( $json_files ) {
+function qtranxf_load_config_files( array $json_files ): array {
     $content_dir = null;
     $qtransx_dir = null;
     foreach ( $json_files as $index => $config_file ) {
@@ -184,7 +184,7 @@ function qtranxf_load_config_files( $json_files ) {
 /**
  * @since 3.4
  */
-function qtranxf_get_option_config_files() {
+function qtranxf_get_option_config_files(): array {
     $config_files_def = array( './i18n-config.json' );
     $config_files     = get_option( 'qtranslate_config_files', $config_files_def );
     if ( ! is_array( $config_files ) ) {
@@ -201,7 +201,7 @@ function qtranxf_get_option_config_files() {
  * @return bool
  * @since 3.4
  */
-function qtranxf_set_field_jquery( &$field ) {
+function qtranxf_set_field_jquery( array &$field ): bool {
     if ( isset( $field['jquery'] ) ) {
         return false;
     }
@@ -233,7 +233,7 @@ function qtranxf_set_field_jquery( &$field ) {
  * @return array
  * @since 3.4
  */
-function qtranxf_standardize_config_fields( $fields ) {
+function qtranxf_standardize_config_fields( array $fields ): array {
     foreach ( $fields as $key => $field ) {
         if ( ! is_array( $field ) ) {
             continue;
@@ -291,7 +291,7 @@ function qtranxf_standardize_config_anchor( &$anchor ) {
  * @return array
  * @since 3.4
  */
-function qtranxf_standardize_front_config( $cfg_front ) {
+function qtranxf_standardize_front_config( array $cfg_front ): array {
     foreach ( $cfg_front as $key => $cfg ) {
         if ( ! isset( $cfg['filters'] ) ) {
             continue;
@@ -330,7 +330,7 @@ function qtranxf_standardize_front_config( $cfg_front ) {
  * @return array
  * @since 3.4
  */
-function qtranxf_standardize_admin_config( $configs ) {
+function qtranxf_standardize_admin_config( array $configs ): array {
     foreach ( $configs as $key => $config ) {
         if ( ! is_array( $config ) ) {
             continue;
@@ -388,7 +388,7 @@ function qtranxf_standardize_admin_config( $configs ) {
  * @return array
  * @since 3.4
  */
-function qtranxf_standardize_i18n_config( $configs ) {
+function qtranxf_standardize_i18n_config( array $configs ): array {
     if ( isset( $configs['admin-config'] ) ) {
         $configs['admin-config'] = qtranxf_standardize_admin_config( $configs['admin-config'] );
     }
@@ -408,7 +408,7 @@ function qtranxf_standardize_i18n_config( $configs ) {
  * @return array dictionary
  * @since 3.4
  */
-function qtranxf_load_config_all( $json_files, $custom_config ) {
+function qtranxf_load_config_all( array $json_files, array $custom_config ): array {
     global $q_config;
     $nerr = isset( $q_config['url_info']['errors'] ) ? count( $q_config['url_info']['errors'] ) : 0;
     $cfg  = qtranxf_load_config_files( $json_files );
@@ -442,7 +442,7 @@ function qtranxf_load_config_all( $json_files, $custom_config ) {
  *
  * @since 3.4
  */
-function qtranxf_update_config_options( $config_files, $changed = true ) {
+function qtranxf_update_config_options( array $config_files, bool $changed = true ): void {
     if ( $changed ) {
         update_option( 'qtranslate_config_files', $config_files );
         qtranxf_update_admin_notice( 'config-files-changed', true ); // notify admin
@@ -462,7 +462,7 @@ function qtranxf_update_config_options( $config_files, $changed = true ) {
  * @return array config files in absolute paths
  * @since 3.4
  */
-function qtranxf_search_config_files_theme( $theme = null ) {
+function qtranxf_search_config_files_theme( $theme = null ): array {
     if ( ! $theme ) {
         $theme = wp_get_theme();
     } elseif ( is_string( $theme ) ) {
@@ -500,7 +500,7 @@ function qtranxf_search_config_files_theme( $theme = null ) {
  * @return array of normalized paths
  * @since 3.4
  */
-function qtranxf_normalize_config_files( $file_paths ) {
+function qtranxf_normalize_config_files( array $file_paths ): array {
     $nc = strlen( WP_CONTENT_DIR );
     $np = strlen( QTRANSLATE_DIR );
     foreach ( $file_paths as $index => $path ) {
@@ -525,7 +525,7 @@ function qtranxf_normalize_config_files( $file_paths ) {
  * @return array of normalized paths
  * @since 3.4
  */
-function qtranxf_search_config_files() {
+function qtranxf_search_config_files(): array {
     $found = qtranxf_search_config_files_theme();
 
     $mu_plugins = wp_get_mu_plugins();
@@ -579,7 +579,7 @@ function qtranxf_search_config_files() {
  * @return array of normalized paths
  * @since 3.4
  */
-function qtranxf_add_config_file( $config_files, $add_file ) {
+function qtranxf_add_config_file( array $config_files, string $add_file ): array {
     $updated   = array_slice( $config_files, 0, 1 );
     $updated[] = $add_file;
     foreach ( array_slice( $config_files, 1 ) as $file ) {
@@ -604,7 +604,7 @@ function qtranxf_add_config_file( $config_files, $add_file ) {
  *
  * @since 3.4
  */
-function qtranxf_add_config_files( &$config_files, $add_files ) {
+function qtranxf_add_config_files( array &$config_files, array $add_files ): bool {
     $changed = false;
     foreach ( $add_files as $file ) {
         $index = array_search( $file, $config_files );
@@ -618,7 +618,7 @@ function qtranxf_add_config_files( &$config_files, $add_files ) {
     return $changed;
 }
 
-function qtranxf_del_config_files( &$config_files, $del_files ) {
+function qtranxf_del_config_files( array &$config_files, array $del_files ): bool {
     $changed = false;
     foreach ( $del_files as $file ) {
         $index = array_search( $file, $config_files );
@@ -635,14 +635,14 @@ function qtranxf_del_config_files( &$config_files, $del_files ) {
 /**
  * @since 3.4
  */
-function qtranxf_update_config_files() {
+function qtranxf_update_config_files(): void {
     $config_files = qtranxf_get_option_config_files();
     $found        = qtranxf_search_config_files();
     $changed      = qtranxf_add_config_files( $config_files, $found );
     qtranxf_update_config_options( $config_files, $changed );
 }
 
-function qtranxf_on_switch_theme( $new_name, $new_theme ) {
+function qtranxf_on_switch_theme( string $new_name, WP_Theme $new_theme ): void {
     $config_files = qtranxf_get_option_config_files();
     $changed      = false;
 
@@ -675,7 +675,7 @@ add_action( 'switch_theme', 'qtranxf_on_switch_theme', 10, 2 );
  *
  * @return string|bool path normalized for qTranslate config, false if not found
  */
-function qtranxf_find_plugin_config_file( $plugin ) {
+function qtranxf_find_plugin_config_file( string $plugin ) {
     $plugin_dirname = dirname( $plugin );
 
     // external configuration prevails
@@ -693,7 +693,7 @@ function qtranxf_find_plugin_config_file( $plugin ) {
     return false;
 }
 
-function qtranxf_adjust_config_files( $file_to_add, $file_to_del ) {
+function qtranxf_adjust_config_files( ?array $file_to_add, ?array $file_to_del ): void {
     $config_files = qtranxf_get_option_config_files();
     if ( $file_to_add ) {
         if ( in_array( $file_to_add, $config_files ) ) {
@@ -715,7 +715,7 @@ function qtranxf_adjust_config_files( $file_to_add, $file_to_del ) {
     }
 }
 
-function qtranxf_on_activate_plugin( $plugin, $network_wide = false ) {
+function qtranxf_on_activate_plugin( string $plugin, bool $network_wide = false ): void {
     if ( $plugin === plugin_basename( QTRANSLATE_FILE ) ) {
         return;
     }
@@ -727,7 +727,7 @@ function qtranxf_on_activate_plugin( $plugin, $network_wide = false ) {
 
 add_action( 'activate_plugin', 'qtranxf_on_activate_plugin' );
 
-function qtranxf_on_deactivate_plugin( $plugin, $network_deactivating = false ) {
+function qtranxf_on_deactivate_plugin( string $plugin, bool $network_deactivating = false ): void {
     if ( $plugin === plugin_basename( QTRANSLATE_FILE ) ) {
         return;
     }
@@ -739,7 +739,7 @@ function qtranxf_on_deactivate_plugin( $plugin, $network_deactivating = false ) 
 
 add_action( 'deactivate_plugin', 'qtranxf_on_deactivate_plugin' );
 
-function qtranxf_clear_debug_log() {
+function qtranxf_clear_debug_log(): void {
     //clear file debug-qtranslate.log
     $file = WP_CONTENT_DIR . '/debug-qtranslate.log';
     if ( file_exists( $file ) ) {
@@ -753,7 +753,7 @@ function qtranxf_clear_debug_log() {
     }
 }
 
-function qtranxf_activation_hook() {
+function qtranxf_activation_hook(): void {
     qtranxf_clear_debug_log();
     if ( version_compare( PHP_VERSION, '7.1' ) < 0 ) {
         // Deactivate ourself
@@ -852,7 +852,7 @@ function qtranxf_activation_hook() {
  *
  * @return bool
  */
-function qtranxf_is_classic_editor_supported() {
+function qtranxf_is_classic_editor_supported(): bool {
     return class_exists( 'Classic_Editor' ) ||
            is_plugin_active( 'disable-gutenberg/disable-gutenberg.php' ) ||
            is_plugin_active( 'no-gutenberg/no-gutenberg.php' );
@@ -861,7 +861,7 @@ function qtranxf_is_classic_editor_supported() {
 /**
  * @since 3.4
  */
-function qtranxf_deactivation_hook() {
+function qtranxf_deactivation_hook(): void {
 
     /**
      * A chance to execute deactivation actions specifically for this plugin.
@@ -869,7 +869,7 @@ function qtranxf_deactivation_hook() {
     do_action( 'qtranslate_deactivation_hook' );
 }
 
-function qtranxf_admin_notice_config_files_changed() {
+function qtranxf_admin_notice_config_files_changed(): void {
     if ( ! qtranxf_check_admin_notice( 'config-files-changed' ) ) {
         return;
     }
@@ -888,7 +888,7 @@ function qtranxf_admin_notice_config_files_changed() {
 
 add_action( 'admin_notices', 'qtranxf_admin_notice_config_files_changed' );
 
-function qtranxf_admin_notice_first_install() {
+function qtranxf_admin_notice_first_install(): void {
     if ( qtranxf_check_admin_notice( 'initial-install' ) ) {
         return;
     }
@@ -907,7 +907,7 @@ add_action( 'admin_notices', 'qtranxf_admin_notice_first_install' );
 /**
  * Show admin notice for block editor (Gutenberg)
  */
-function qtranxf_admin_notices_block_editor() {
+function qtranxf_admin_notices_block_editor(): void {
     if ( qtranxf_check_admin_notice( 'gutenberg-support' ) ) {
         return;
     }
@@ -931,7 +931,7 @@ function qtranxf_admin_notices_block_editor() {
 
 add_action( 'admin_notices', 'qtranxf_admin_notices_block_editor' );
 
-function qtranxf_admin_notices_slugs_migrate() {
+function qtranxf_admin_notices_slugs_migrate(): void {
     if ( qtranxf_check_admin_notice( 'slugs-migrate' ) || ! QTX_Module_Loader::is_module_active( 'slugs' ) ) {
         return;
     }
@@ -955,7 +955,7 @@ function qtranxf_admin_notices_slugs_migrate() {
 
 add_action( 'admin_notices', 'qtranxf_admin_notices_slugs_migrate' );
 
-function qtranxf_admin_notice_deactivate_plugin( $name, $plugin ) {
+function qtranxf_admin_notice_deactivate_plugin( $name, $plugin ): void {
     deactivate_plugins( $plugin, true );
     $d        = dirname( $plugin );
     $link     = '<a href="https://wordpress.org/plugins/' . $d . '/" target="_blank">' . $name . '</a>';
@@ -981,7 +981,7 @@ function qtranxf_admin_notice_deactivate_plugin( $name, $plugin ) {
     wp_die( '<p>' . $msg . '</p>' );
 }
 
-function qtranxf_admin_notice_plugin_conflict( $title, $plugin ) {
+function qtranxf_admin_notice_plugin_conflict( $title, $plugin ): void {
     if ( ! is_plugin_active( $plugin ) ) {
         return;
     }
@@ -999,7 +999,7 @@ function qtranxf_admin_notice_plugin_conflict( $title, $plugin ) {
     echo '</p></div>';
 }
 
-function qtranxf_admin_notices_plugin_conflicts() {
+function qtranxf_admin_notices_plugin_conflicts(): void {
     qtranxf_admin_notice_plugin_conflict( 'qTranslate', 'qtranslate/qtranslate.php' );
     qtranxf_admin_notice_plugin_conflict( 'mqTranslate', 'mqtranslate/mqtranslate.php' );
     qtranxf_admin_notice_plugin_conflict( 'qTranslate Plus', 'qtranslate-xp/ppqtranslate.php' );
@@ -1009,11 +1009,11 @@ function qtranxf_admin_notices_plugin_conflicts() {
 
 add_action( 'admin_notices', 'qtranxf_admin_notices_plugin_conflicts' );
 
-function qtranxf_get_plugin_link() {
+function qtranxf_get_plugin_link(): string {
     return '<a href="https://github.com/qTranslate/qtranslate-xt/" target="_blank">qTranslate&#8209;XT</a>';
 }
 
-function qtranxf_admin_notices_errors() {
+function qtranxf_admin_notices_errors(): void {
     $msgs = get_option( 'qtranslate_config_errors' );
     if ( ! is_array( $msgs ) ) {
         return;
@@ -1028,7 +1028,7 @@ function qtranxf_admin_notices_errors() {
 
 add_action( 'admin_notices', 'qtranxf_admin_notices_errors' );
 
-function qtranxf_check_admin_notice( $id ) {
+function qtranxf_check_admin_notice( string $id ) {
     $messages = get_option( 'qtranslate_admin_notices' );
     if ( isset( $messages[ $id ] ) ) {
         return $messages[ $id ];
@@ -1037,7 +1037,7 @@ function qtranxf_check_admin_notice( $id ) {
     return false;
 }
 
-function qtranxf_update_option_admin_notices( $messages, $id, $set = true ) {
+function qtranxf_update_option_admin_notices( $messages, string $id, bool $set = true ) {
     if ( ! is_array( $messages ) ) {
         $messages = array();
     }
@@ -1059,13 +1059,13 @@ function qtranxf_update_option_admin_notices( $messages, $id, $set = true ) {
  *
  * @return array|mixed
  */
-function qtranxf_update_admin_notice( $id, $set ) {
+function qtranxf_update_admin_notice( string $id, bool $set ) {
     $messages = get_option( 'qtranslate_admin_notices', array() );
 
     return qtranxf_update_option_admin_notices( $messages, $id, $set );
 }
 
-function qtranxf_ajax_qtranslate_admin_notice() {
+function qtranxf_ajax_qtranslate_admin_notice(): void {
     if ( ! isset( $_POST['notice_id'] ) ) {
         return;
     }
@@ -1076,7 +1076,7 @@ function qtranxf_ajax_qtranslate_admin_notice() {
 
 add_action( 'wp_ajax_qtranslate_admin_notice', 'qtranxf_ajax_qtranslate_admin_notice' );
 
-function qtranxf_admin_notice_dismiss_script() {
+function qtranxf_admin_notice_dismiss_script(): void {
     static $admin_notice_dismiss_script;
     if ( $admin_notice_dismiss_script ) {
         return;
@@ -1087,7 +1087,7 @@ function qtranxf_admin_notice_dismiss_script() {
 }
 
 /** register activation/deactivation hooks */
-function qtranxf_register_activation_hooks() {
+function qtranxf_register_activation_hooks(): void {
     $qtx_plugin_basename = plugin_basename( QTRANSLATE_FILE );
     register_activation_hook( $qtx_plugin_basename, 'qtranxf_activation_hook' );
     register_deactivation_hook( $qtx_plugin_basename, 'qtranxf_deactivation_hook' );

--- a/src/admin/admin.php
+++ b/src/admin/admin.php
@@ -13,7 +13,7 @@ require_once QTRANSLATE_DIR . '/src/admin/admin_taxonomy.php';
 /**
  * @see qtranxf_collect_translations
  */
-function qtranxf_collect_translations_deep( $qfields, $sep ) {
+function qtranxf_collect_translations_deep( $qfields, string $sep ) {
     $content = reset( $qfields );
     if ( is_string( $content ) ) {
         return qtranxf_join_texts( $qfields, $sep );
@@ -40,7 +40,7 @@ function qtranxf_collect_translations_deep( $qfields, $sep ) {
  * @param array|string $request an ML field of $_REQUEST.
  * @param string $edit_lang language of the active LSB at the time of sending the request.
  */
-function qtranxf_collect_translations( &$qfields, &$request, $edit_lang ) {
+function qtranxf_collect_translations( array &$qfields, &$request, string $edit_lang ): void {
     if ( isset( $qfields['qtranslate-separator'] ) ) {
         $sep = $qfields['qtranslate-separator'];
         unset( $qfields['qtranslate-separator'] );

--- a/src/admin/admin_options.php
+++ b/src/admin/admin_options.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 require_once QTRANSLATE_DIR . '/src/admin/admin_utils.php';
 require_once QTRANSLATE_DIR . '/src/modules/admin_module.php';
 
-function qtranxf_admin_set_default_options( &$options ) {
+function qtranxf_admin_set_default_options( array &$options ): void {
     // options processed in a standardized way
     $options['admin'] = array();
 
@@ -49,7 +49,7 @@ function qtranxf_admin_set_default_options( &$options ) {
     $options = apply_filters( 'qtranslate_option_config_admin', $options );
 }
 
-function qtranxf_admin_load_config() {
+function qtranxf_admin_load_config(): void {
     global $q_config, $qtranslate_options;
     qtranxf_admin_set_default_options( $qtranslate_options );
 
@@ -99,7 +99,7 @@ function qtranxf_admin_load_config() {
  *
  * @return void
  */
-function qtranxf_import_legacy_option( $old_name, $new_name, $autoload = null ) {
+function qtranxf_import_legacy_option( string $old_name, string $new_name, $autoload = null ): void {
     assert( strpos( $new_name, 'qtranslate_' ) === 0 );
     if ( ! get_option( $new_name ) ) {
         $old_value = get_option( $old_name );
@@ -115,11 +115,11 @@ function qtranxf_import_legacy_option( $old_name, $new_name, $autoload = null ) 
  *
  * @param string $old_name
  * @param string $new_name
- * @param bool|string $autoload as in update_option
+ * @param bool|string|null $autoload as in update_option
  *
  * @return void
  */
-function qtranxf_rename_legacy_option( $old_name, $new_name, $autoload = null ) {
+function qtranxf_rename_legacy_option( string $old_name, string $new_name, $autoload = null ): void {
     assert( strpos( $new_name, 'qtranslate_' ) === 0 );
     assert( strpos( $old_name, 'qtranslate_' ) === 0 );
     qtranxf_import_legacy_option( $old_name, $new_name, $autoload );

--- a/src/admin/admin_options_update.php
+++ b/src/admin/admin_options_update.php
@@ -7,7 +7,7 @@ require_once QTRANSLATE_DIR . '/src/admin/admin_options.php';
 require_once QTRANSLATE_DIR . '/src/admin/import_export.php';
 require_once QTRANSLATE_DIR . '/src/modules/admin_module_manager.php';
 
-function qtranxf_edit_config() {
+function qtranxf_edit_config(): void {
     global $q_config;
     if ( ! qtranxf_verify_nonce( 'qtranslate-x_configuration_form' ) ) {
         return;
@@ -311,7 +311,7 @@ function qtranxf_edit_config() {
     }
 }
 
-function qtranxf_reset_config() {
+function qtranxf_reset_config(): void {
     global $qtranslate_options;
 
     if ( ! current_user_can( 'manage_options' ) ) {
@@ -374,7 +374,7 @@ function qtranxf_reset_config() {
 
 add_action( 'qtranslate_save_config', 'qtranxf_reset_config', 20 );
 
-function qtranxf_update_option( $nm, $default_value = null ) {
+function qtranxf_update_option( string $nm, $default_value = null ): void {
     global $q_config;
     if ( ! isset( $q_config[ $nm ] ) || ( ! is_integer( $q_config[ $nm ] ) && empty( $q_config[ $nm ] ) ) ) {
         delete_option( 'qtranslate_' . $nm );
@@ -398,7 +398,7 @@ function qtranxf_update_option( $nm, $default_value = null ) {
     update_option( 'qtranslate_' . $nm, $q_config[ $nm ] );
 }
 
-function qtranxf_update_option_bool( $nm, $default_value = null ) {
+function qtranxf_update_option_bool( string $nm, $default_value = null ): void {
     global $q_config, $qtranslate_options;
     if ( ! isset( $q_config[ $nm ] ) ) {
         delete_option( 'qtranslate_' . $nm );
@@ -422,7 +422,7 @@ function qtranxf_update_option_bool( $nm, $default_value = null ) {
 /**
  * saves entire configuration
  */
-function qtranxf_save_config() {
+function qtranxf_save_config(): void {
     global $q_config, $qtranslate_options;
 
     qtranxf_update_option( 'default_language' );
@@ -484,7 +484,7 @@ function qtranxf_save_config() {
     do_action_deprecated( 'qtranslate_saveConfig', array(), '3.10.0', 'qtranslate_save_config' );
 }
 
-function qtranxf_reload_config() {
+function qtranxf_reload_config(): void {
     global $q_config;
     $url_info = $q_config['url_info'] ?? null;
     qtranxf_del_conf_filters();
@@ -502,7 +502,7 @@ function qtranxf_reload_config() {
     qtranxf_load_option_qtrans_compatibility();
 }
 
-function qtranxf_update_setting( $var, $type = QTX_STRING, $def = null ) {
+function qtranxf_update_setting( $var, int $type = QTX_STRING, $def = null ): bool {
     global $q_config, $qtranslate_options;
     if ( ! isset( $_POST['submit'] ) ) {
         return false;
@@ -650,7 +650,7 @@ function qtranxf_update_setting( $var, $type = QTX_STRING, $def = null ) {
  * Updates 'admin_config' and 'front_config' from *.json files listed in option 'config_files', and option 'custom_i18n_config'.
  * @since 3.3.1
  */
-function qtranxf_update_i18n_config() {
+function qtranxf_update_i18n_config(): void {
     global $q_config;
     if ( ! isset( $q_config['config_files'] ) ) {
         global $qtranslate_options;
@@ -672,7 +672,7 @@ function qtranxf_update_i18n_config() {
     }
 }
 
-function qtranxf_update_setting_flag_location( $nm ) {
+function qtranxf_update_setting_flag_location( string $nm ): bool {
     global $q_config;
     if ( ! isset( $_POST['submit'] ) ) {
         return false;
@@ -686,7 +686,7 @@ function qtranxf_update_setting_flag_location( $nm ) {
     }
     $flag_location = trailingslashit( $flag_location );
     if ( ! file_exists( trailingslashit( WP_CONTENT_DIR ) . $flag_location ) ) {
-        return null;
+        return false;
     }
     if ( $flag_location != $q_config[ $nm ] ) {
         $q_config[ $nm ] = $flag_location;
@@ -700,7 +700,7 @@ function qtranxf_update_setting_flag_location( $nm ) {
     return true;
 }
 
-function qtranxf_update_setting_ignore_file_types( $name ) {
+function qtranxf_update_setting_ignore_file_types( string $name ): bool {
     global $q_config;
     if ( ! isset( $_POST['submit'] ) ) {
         return false;
@@ -730,7 +730,7 @@ function qtranxf_update_setting_ignore_file_types( $name ) {
     return true;
 }
 
-function qtranxf_parse_post_type_excluded() {
+function qtranxf_parse_post_type_excluded(): bool {
     if ( ! isset( $_POST['submit'] ) ) {
         return false;
     }
@@ -754,7 +754,7 @@ function qtranxf_parse_post_type_excluded() {
     return true;
 }
 
-function qtranxf_update_settings() {
+function qtranxf_update_settings(): void {
     global $qtranslate_options, $q_config;
 
     $errors = &$q_config['url_info']['errors'];
@@ -914,7 +914,7 @@ function qtranxf_update_settings() {
     do_action( 'qtranslate_update_settings' );
 }
 
-function qtranxf_executeOnUpdate() {
+function qtranxf_executeOnUpdate(): void {
     global $q_config;
     $messages = &$q_config['url_info']['messages'];
 

--- a/src/admin/admin_settings.php
+++ b/src/admin/admin_settings.php
@@ -24,16 +24,16 @@ class QTX_Admin_Settings {
         $this->options_uri = admin_url( 'options-general.php?page=qtranslate-xt' );
     }
 
-    public static function add_submit_button( $button_name ) {
+    public static function add_submit_button( string $button_name ): void {
         echo '<p class="submit"><input type="submit" name="submit" class="button-primary"';
         echo ' value="' . $button_name . '" /></p>' . PHP_EOL;
     }
 
-    public static function open_section( $name ) {
+    public static function open_section( string $name ): void {
         echo '<div id="tab-' . $name . '" class="hidden">' . PHP_EOL;
     }
 
-    public static function close_section( $name, $button_name = null ) {
+    public static function close_section( string $name, ?string $button_name = null ): void {
         if ( $button_name !== false ) {
             if ( is_null( $button_name ) ) {
                 $button_name = __( 'Save Changes', 'qtranslate' );
@@ -43,7 +43,7 @@ class QTX_Admin_Settings {
         echo '</div>' . PHP_EOL;
     }
 
-    public function display() {
+    public function display(): void {
         $nonce_action = 'qtranslate-x_configuration_form';
         if ( ! qtranxf_verify_nonce( $nonce_action ) ) {
             return;
@@ -80,7 +80,7 @@ class QTX_Admin_Settings {
         <?php
     }
 
-    private function add_language_form( $form_action, $button_name, $nonce_action ) {
+    private function add_language_form( string $form_action, string $button_name, $nonce_action ): void {
         global $q_config;
 
         $language_code = $q_config['posted']['language_code'] ?? '';
@@ -204,7 +204,7 @@ class QTX_Admin_Settings {
         <?php
     }
 
-    private function add_configuration_inspector() {
+    private function add_configuration_inspector(): void {
         global $q_config;
 
         $admin_config = $q_config['admin_config'];
@@ -245,7 +245,7 @@ class QTX_Admin_Settings {
         <?php
     }
 
-    private function add_sections( $nonce_action ) {
+    private function add_sections( $nonce_action ): void {
         $admin_sections             = array();
         $admin_sections['general']  = __( 'General', 'qtranslate' );
         $admin_sections['advanced'] = __( 'Advanced', 'qtranslate' );
@@ -287,7 +287,7 @@ class QTX_Admin_Settings {
         <?php
     }
 
-    private function add_general_section() {
+    private function add_general_section(): void {
         global $q_config;
 
         $permalink_is_query = qtranxf_is_permalink_structure_query();
@@ -454,7 +454,7 @@ class QTX_Admin_Settings {
         $this->close_section( 'general' );
     }
 
-    private function add_advanced_section() {
+    private function add_advanced_section(): void {
         global $q_config;
         $url_mode = $q_config['url_mode'];
 
@@ -724,7 +724,7 @@ class QTX_Admin_Settings {
      *
      * @return void
      */
-    private function add_integration_section( $settings_modules ) {
+    private function add_integration_section( array $settings_modules ): void {
         global $q_config;
 
         $this->open_section( 'integration' ); ?>
@@ -859,7 +859,7 @@ class QTX_Admin_Settings {
         <?php $this->close_section( 'integration' );
     }
 
-    private function add_troubleshooting_section() {
+    private function add_troubleshooting_section(): void {
         $this->open_section( 'troubleshooting' ); ?>
         <table class="form-table qtranxs-form-table" id="qtranxs_troubleshooting_config">
             <tr>
@@ -893,7 +893,7 @@ class QTX_Admin_Settings {
         $this->close_section( 'troubleshooting' );
     }
 
-    private function add_languages_section( $nonce_action ) {
+    private function add_languages_section( $nonce_action ): void {
         $this->open_section( 'languages' ); ?>
         <div id="col-container">
 

--- a/src/admin/admin_settings_language_list.php
+++ b/src/admin/admin_settings_language_list.php
@@ -23,7 +23,7 @@ class QTX_Admin_Settings_Language_List extends WP_List_Table {
         $this->options_uri    = $options_uri;
     }
 
-    public function get_columns() {
+    public function get_columns(): array {
         return array(
             'code'   => _x( 'Code', 'Two-letter Language Code meant.', 'qtranslate' ),
             'flag'   => __( 'Flag', 'qtranslate' ),
@@ -36,7 +36,7 @@ class QTX_Admin_Settings_Language_List extends WP_List_Table {
         );
     }
 
-    public function prepare_items() {
+    public function prepare_items(): void {
         global $q_config;
 
         $flags                 = qtranxf_language_configured( 'flag' );
@@ -109,18 +109,18 @@ class QTX_Admin_Settings_Language_List extends WP_List_Table {
         $this->items = $data;
     }
 
-    protected function column_default( $item, $column_name ) {
+    protected function column_default( $item, $column_name ): string {
         return $item[ $column_name ];
     }
 
-    protected function get_default_primary_column_name() {
+    protected function get_default_primary_column_name(): string {
         return 'name';
     }
 
-    protected function display_tablenav( $which ) {
+    protected function display_tablenav( $which ): void {
     }
 
-    protected function get_table_classes() {
+    protected function get_table_classes(): array {
         return array( 'widefat', 'qtranxs-language-list' );
     }
 }

--- a/src/admin/admin_taxonomy.php
+++ b/src/admin/admin_taxonomy.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @return string Raw ML string
  */
-function qtranxf_term_name_encoded( $name ) {
+function qtranxf_term_name_encoded( string $name ): string {
     global $q_config;
     if ( isset( $q_config['term_name'][ $name ] ) ) {
         $name = qtranxf_join_b( $q_config['term_name'][ $name ] );
@@ -19,7 +19,7 @@ function qtranxf_term_name_encoded( $name ) {
     return $name;
 }
 
-function qtranxf_get_term_joined( $obj, $taxonomy = null ) {
+function qtranxf_get_term_joined( $obj, ?string $taxonomy = null ) {
     global $q_config;
     if ( is_object( $obj ) ) {
         // WP_Term object conversion
@@ -39,16 +39,16 @@ function qtranxf_get_term_joined( $obj, $taxonomy = null ) {
 }
 
 /**
- * @param string $lang two-letter language code to search for $term.
- * @param string $default_lang two-letter language code of the default language.
+ * @param string $lang language code to search for $term.
+ * @param string $default_lang language code of the default language.
  * @param string $term name of term in language $lang.
- * @param string $taxonomy is not used for now.
+ * @param string|null $taxonomy is not used for now.
  *
  * @return array translations of the term found.
  *
  * @since 3.4.6.8
  */
-function qtranxf_term_find_translations( $lang, $default_lang, $term, $taxonomy = null ) {
+function qtranxf_term_find_translations( string $lang, string $default_lang, string $term, ?string $taxonomy = null ): ?array {
     global $q_config;
     if ( empty( $default_lang ) ) {
         $default_lang = $q_config['default_language'];
@@ -108,10 +108,18 @@ function qtranxf_useAdminTermLibJoin( $obj, $taxonomies = null, $args = null ) {
 }
 
 /**
- * @since 3.4.6.8
+ * Sanitize term name.
  * Called in 'sanitize_term_field' with default context like 'display'.
+ *
+ * @param mixed $value
+ * @param int|WP_Term $term
+ * @param string|null $taxonomy
+ * @param string|null $context
+ *
+ * @return __PHP_Incomplete_Class|array|mixed|string
+ * @since 3.4.6.8
  */
-function qtranxf_term_sanitize_name( $value, $term, $taxonomy = null, $context = null ) {
+function qtranxf_term_sanitize_name( $value, $term, ?string $taxonomy = null, ?string $context = null ) {
     global $pagenow;
     if ( $context == 'display' && $pagenow == 'edit.php' ) {
         return qtranxf_useCurrentLanguageIfNotFoundUseDefaultLanguage( $value );
@@ -120,14 +128,14 @@ function qtranxf_term_sanitize_name( $value, $term, $taxonomy = null, $context =
     return $value;
 }
 
-add_filter( 'term_name', 'qtranxf_term_sanitize_name', 5, 4 );//used in function sanitize_term_field called from function sanitize_term with default context like 'display'
+add_filter( 'term_name', 'qtranxf_term_sanitize_name', 5, 4 ); // used in function sanitize_term_field called from function sanitize_term with default context like 'display'
 
 /**
  * @since 3.4.6.9
  * Version of function qtranxf_term_sanitize_name_db for unslashed argument $term.
  * ['terms_sanitized'][$term] for possible further processing.
  */
-function qtranxf_term_sanitize_name_unslashed( $term, $taxonomy = null ) {
+function qtranxf_term_sanitize_name_unslashed( $term, ?string $taxonomy = null ) {
     global $q_config;
     $default_lang = $q_config['default_language'];
     if ( qtranxf_isMultilingual( $term ) ) {
@@ -156,15 +164,15 @@ function qtranxf_term_sanitize_name_unslashed( $term, $taxonomy = null ) {
 }
 
 /**
- * @param string $term slashed value of a term name, which may be an ML value.
- * @param string $taxonomy provided to the filter, but is not used here.
+ * @param mixed $term slashed value of a term name, which may be an ML value.
+ * @param string|null $taxonomy provided to the filter, but is not used here.
  *
- * @return string slashed term name in the default language. Translations found are stored for possible further processing in $q_config['terms_sanitized'][$term_db], where $term_db is an unslashed value of term name in the default language.
+ * @return mixed slashed term name in the default language. Translations found are stored for possible further processing in $q_config['terms_sanitized'][$term_db], where $term_db is an unslashed value of term name in the default language.
  * @since 3.4.6.9
  * Response to filter "pre_term_{$field}" in function 'sanitize_term_field' with $field='name' and $context='db'
  *
  */
-function qtranxf_term_sanitize_name_db( $term, $taxonomy = null ) {
+function qtranxf_term_sanitize_name_db( $term, ?string $taxonomy = null ) {
     global $q_config;
 
     if ( ! qtranxf_isMultilingual( $term ) ) {
@@ -186,7 +194,7 @@ function qtranxf_term_sanitize_name_db( $term, $taxonomy = null ) {
  * @since 3.4.6.9
  * Response to filter 'get_terms_args', data is unslashed.
  */
-function qtranxf_term_get_args( $args, $taxonomies = null ) {
+function qtranxf_term_get_args( array $args, ?array $taxonomies = null ): array {
     if ( ! empty( $args['name'] ) ) {
         // expected in default language after applying sanitize_term_field
         $names = $args['name'];
@@ -234,7 +242,7 @@ function qtranxf_term_get_args( $args, $taxonomies = null ) {
  * response to action 'edit_term', removes old translations
  * @since 3.4.6.9
  */
-function qtranxf_term_del_translation( $term_id, $tt_id, $taxonomy ) {
+function qtranxf_term_del_translation( int $term_id, int $tt_id, string $taxonomy ) {
     $term = wp_cache_get( $term_id, 'terms' );
     if ( ! $term ) {
         return;
@@ -266,7 +274,7 @@ add_action( 'edit_term', 'qtranxf_term_del_translation', 5, 3 );
  * response to actions 'created_term' and 'edited_term'
  * @since 3.4.6.9
  */
-function qtranxf_term_set_translation( $term_id, $tt_id, $taxonomy ) {
+function qtranxf_term_set_translation( int $term_id, int $tt_id, string $taxonomy ): void {
     global $q_config;
     if ( empty( $q_config['terms_sanitized'] ) ) {
         return;
@@ -320,7 +328,7 @@ function qtranxf_term_set_translation( $term_id, $tt_id, $taxonomy ) {
 add_action( 'created_term', 'qtranxf_term_set_translation', 5, 3 );
 add_action( 'edited_term', 'qtranxf_term_set_translation', 5, 3 );
 
-function qtranxf_term_delete( $term, $tt_id, $taxonomy, $deleted_term, $object_ids ) {
+function qtranxf_term_delete( int $term, int $tt_id, string $taxonomy, WP_Term $deleted_term, array $object_ids ): void {
     global $q_config;
     if ( isset( $deleted_term->i18n_config['name'] ) ) {
         $default_language = $q_config['default_language'];
@@ -338,7 +346,7 @@ function qtranxf_term_delete( $term, $tt_id, $taxonomy, $deleted_term, $object_i
 
 add_action( 'delete_term', 'qtranxf_term_delete', 5, 5 );
 
-function qtranxf_admin_list_cats( $text ) {
+function qtranxf_admin_list_cats( string $text ): string {
     global $pagenow;
     switch ( $pagenow ) {
         case 'edit-tags.php':
@@ -359,7 +367,7 @@ function qtranxf_admin_list_cats( $text ) {
 
 add_filter( 'list_cats', 'qtranxf_admin_list_cats', 0 );
 
-function qtranxf_admin_dropdown_cats( $text ) {
+function qtranxf_admin_dropdown_cats( string $text ): string {
     global $pagenow;
     switch ( $pagenow ) {
         case 'edit-tags.php':
@@ -372,7 +380,7 @@ function qtranxf_admin_dropdown_cats( $text ) {
 
 add_filter( 'wp_dropdown_cats', 'qtranxf_admin_dropdown_cats', 0 );
 
-function qtranxf_admin_category_description( $text ) {
+function qtranxf_admin_category_description( string $text ): string {
     global $pagenow;
     switch ( $pagenow ) {
         case 'term.php':
@@ -396,7 +404,7 @@ function qtranxf_term_admin_add_filters() {
     add_filter( 'get_term', 'qtranxf_useAdminTermLibJoin', 5, 2 );
     add_filter( 'get_terms', 'qtranxf_useAdminTermLibJoin', 5, 3 );
     add_filter( 'get_terms_args', 'qtranxf_term_get_args', 5, 2 );
-    add_filter( 'pre_term_name', 'qtranxf_term_sanitize_name_db', 999, 2 );//"pre_term_{$field}" in function sanitize_term_field with $field='name' and $context='db'
+    add_filter( 'pre_term_name', 'qtranxf_term_sanitize_name_db', 999, 2 ); // "pre_term_{$field}" in function sanitize_term_field with $field='name' and $context='db'
 }
 
 qtranxf_term_admin_add_filters();

--- a/src/admin/admin_utils.php
+++ b/src/admin/admin_utils.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * @since 3.3.8.4
  */
-function qtranxf_add_admin_notice( $msg, $kind ) {
+function qtranxf_add_admin_notice( string $msg, string $kind ): void {
     global $q_config;
     if ( isset( $q_config['url_info'][ $kind ] ) ) {
         if ( ! in_array( $msg, $q_config['url_info'][ $kind ] ) ) {
@@ -23,22 +23,22 @@ function qtranxf_add_admin_notice( $msg, $kind ) {
 /**
  * @since 3.3.7
  */
-function qtranxf_add_error( $msg ) {
+function qtranxf_add_error( string $msg ): void {
     qtranxf_add_admin_notice( $msg, 'errors' );
 }
 
-function qtranxf_add_warning( $msg ) {
+function qtranxf_add_warning( string $msg ): void {
     qtranxf_add_admin_notice( $msg, 'warnings' );
 }
 
-function qtranxf_add_message( $msg ) {
+function qtranxf_add_message( string $msg ): void {
     qtranxf_add_admin_notice( $msg, 'messages' );
 }
 
 /**
  * @since 3.3.1
  */
-function qtranxf_error_log( $msg ) {
+function qtranxf_error_log( string $msg ): void {
     qtranxf_add_error( $msg );
     error_log( 'qTranslate-X: ' . strip_tags( $msg ) );
 }
@@ -47,7 +47,7 @@ function qtranxf_error_log( $msg ) {
  * Enqueue Javascript files listed in $jss.
  * @since 3.5.1
  */
-function qtranxf_enqueue_scripts( $jss ) {
+function qtranxf_enqueue_scripts( array $jss ): void {
     $cnt  = 0;
     $deps = array();
     foreach ( $jss as $key => $js ) {
@@ -66,7 +66,7 @@ function qtranxf_enqueue_scripts( $jss ) {
     }
 }
 
-function qtranxf_detect_admin_language( $url_info ) {
+function qtranxf_detect_admin_language( array $url_info ): array {
     global $q_config;
     $cs   = null;
     $lang = null;
@@ -115,7 +115,7 @@ add_filter( 'qtranslate_detect_admin_language', 'qtranxf_detect_admin_language' 
 /**
  * @return bool true if $a and $b are equal.
  */
-function qtranxf_array_compare( $a, $b ) {
+function qtranxf_array_compare( $a, $b ): bool {
     if ( ! is_array( $a ) || ! is_array( $b ) ) {
         return false;
     }
@@ -140,7 +140,7 @@ function qtranxf_array_compare( $a, $b ) {
     return true;
 }
 
-function qtranxf_join_texts( $texts, $sep ) {
+function qtranxf_join_texts( $texts, string $sep ): string {
     switch ( $sep ) {
         case 'byline':
             return qtranxf_join_byline( $texts );
@@ -154,13 +154,14 @@ function qtranxf_join_texts( $texts, $sep ) {
 /**
  * @since 3.4.6.9
  */
-function qtranxf_clean_request( $name ) {
+function qtranxf_clean_request( string $name ): void {
     unset( $_GET[ $name ] );
     unset( $_POST[ $name ] );
     unset( $_REQUEST[ $name ] );
 }
 
-function qtranxf_ensure_language_set( &$langs, $lang, $default_value = null ) {
+// TODO clarify return value
+function qtranxf_ensure_language_set( array &$langs, string $lang, ?string $default_value = null ) {
     if ( ! empty( $langs[ $lang ] ) ) {
         return $langs[ $lang ];
     }
@@ -179,7 +180,7 @@ function qtranxf_ensure_language_set( &$langs, $lang, $default_value = null ) {
     return '';
 }
 
-function qtranxf_get_edit_language() {
+function qtranxf_get_edit_language(): string {
     global $q_config;
 
     if ( ! isset( $_REQUEST['qtranslate-edit-language'] ) ) {
@@ -194,7 +195,7 @@ function qtranxf_get_edit_language() {
     return $lang;
 }
 
-function qtranxf_language_column_header( $columns ) {
+function qtranxf_language_column_header( array $columns ): array {
     $new_columns = array();
     if ( isset( $columns['cb'] ) ) {
         $new_columns['cb'] = '';
@@ -216,7 +217,7 @@ function qtranxf_language_column_header( $columns ) {
     return array_merge( $new_columns, $columns );
 }
 
-function qtranxf_language_column( $column ) {
+function qtranxf_language_column( string $column ) {
     global $q_config, $post;
     if ( $column == 'language' ) {
         $missing_languages   = null;
@@ -253,7 +254,7 @@ function qtranxf_language_column( $column ) {
     return $column;
 }
 
-function qtranxf_before_admin_bar_render() {
+function qtranxf_before_admin_bar_render(): void {
     global $wp_admin_bar, $q_config;
     if ( ! isset( $wp_admin_bar ) ) {
         return;
@@ -271,7 +272,7 @@ function qtranxf_before_admin_bar_render() {
     }
 }
 
-function qtranxf_admin_the_title( $title ) {
+function qtranxf_admin_the_title( string $title ): string {
     // For nav menus, keep the raw value as the languages are handled client-side (LSB)
     if ( wp_doing_ajax() && isset( $_REQUEST['action'] ) && $_REQUEST['action'] == 'add-menu-item' ) {
         // When a nav menu is being added it is first handled by AJAX, see "wp_ajax_add_menu_item" in ajax-actions.php
@@ -292,7 +293,8 @@ function qtranxf_admin_the_title( $title ) {
 add_filter( 'the_title', 'qtranxf_admin_the_title', 0 );
 
 if ( ! function_exists( 'qtranxf_trim_words' ) ) {
-    function qtranxf_trim_words( $text, $num_words, $more, $original_text ) {
+    // TODO clarify duplicate function name, defined in frontend!
+    function qtranxf_trim_words( string $text, int $num_words, string $more, string $original_text ) {
         $blocks = qtranxf_get_language_blocks( $original_text );
         if ( count( $blocks ) <= 1 ) {
             return $text;
@@ -487,6 +489,6 @@ function qtranxf_decode_name_value( $name_values ) {
 }
 
 add_filter( 'manage_posts_columns', 'qtranxf_language_column_header' );
-add_filter( 'manage_posts_custom_column', 'qtranxf_language_column' );
+add_filter( 'manage_posts_custom_column', 'qtranxf_language_column' );  // TODO this should be an action!
 add_filter( 'manage_pages_columns', 'qtranxf_language_column_header' );
-add_filter( 'manage_pages_custom_column', 'qtranxf_language_column' );
+add_filter( 'manage_pages_custom_column', 'qtranxf_language_column' );  // TODO this should be an action!

--- a/src/admin/admin_utils_db.php
+++ b/src/admin/admin_utils_db.php
@@ -1,6 +1,6 @@
 <?php
 
-function qtranxf_convert_database( $action ) {
+function qtranxf_convert_database( string $action ): string {
     switch ( $action ) {
         case 'b_only':
         case 'c_dual':
@@ -179,7 +179,7 @@ function qtranxf_convert_to_b_no_closing_deep( $text ) {
     return qtranxf_convert_to_b_no_closing( $text );
 }
 
-function qtranxf_convert_database_options( $action ) {
+function qtranxf_convert_database_options( string $action ): void {
     global $wpdb;
 
     $wpdb->show_errors();
@@ -223,7 +223,7 @@ function qtranxf_convert_database_options( $action ) {
     }
 }
 
-function qtranxf_convert_database_posts( $action ) {
+function qtranxf_convert_database_posts( string $action ): void {
     global $wpdb;
 
     $result = $wpdb->get_results( 'SELECT ID, post_title, post_content, post_excerpt FROM ' . $wpdb->posts );
@@ -260,7 +260,7 @@ function qtranxf_convert_database_posts( $action ) {
     }
 }
 
-function qtranxf_convert_database_postmeta( $action ) {
+function qtranxf_convert_database_postmeta( string $action ): void {
     global $wpdb;
     $result = $wpdb->get_results( 'SELECT meta_id, meta_value FROM ' . $wpdb->postmeta );
     if ( ! $result ) {
@@ -302,7 +302,7 @@ function qtranxf_convert_database_postmeta( $action ) {
 
 /**
  */
-function qtranxf_split_database_file( $ifp, $languages_to_keep ) {
+function qtranxf_split_database_file( string $ifp, array $languages_to_keep ): string {
     global $q_config;
     $errors = $q_config['url_info']['errors'];
     $ifh    = fopen( $ifp, 'r' );
@@ -425,7 +425,7 @@ function qtranxf_split_database_file( $ifp, $languages_to_keep ) {
     return sprintf( __( 'The database file provided has been split as requested. Number of multilingual strings found is %s. The result files are:%s', 'qtranslate' ), $cnt, $fns );
 }
 
-function qtranxf_extract_languages( $text, $lang2keep ) {
+function qtranxf_extract_languages( $text, array $lang2keep ): string {
     $blocks           = qtranxf_get_language_blocks( $text );
     $s                = '';
     $current_language = false;
@@ -485,7 +485,8 @@ function qtranxf_extract_languages( $text, $lang2keep ) {
     return $s;
 }
 
-function gtranxf_db_clean_terms() {
+// TODO: fix gtranxf typo
+function gtranxf_db_clean_terms(): string {
     global $wpdb, $q_config;
     $errors   = &$q_config['url_info']['errors'];
     $messages = &$q_config['url_info']['messages'];

--- a/src/admin/block_editor.php
+++ b/src/admin/block_editor.php
@@ -26,7 +26,7 @@ class QTX_Admin_Block_Editor {
     /**
      * Register the REST filters
      */
-    public function rest_api_init() {
+    public function rest_api_init(): void {
         global $q_config;
 
         // Filter to allow qTranslate-XT to manage the block editor (single language mode)
@@ -58,7 +58,7 @@ class QTX_Admin_Block_Editor {
      *
      * @return mixed
      */
-    public function rest_prepare( $response, $post, $request ) {
+    public function rest_prepare( WP_REST_Response $response, WP_Post $post, WP_REST_Request $request ) {
         global $q_config;
 
         if ( $request->get_param( 'context' ) !== 'edit' || $request->get_method() !== 'GET' ) {
@@ -85,13 +85,13 @@ class QTX_Admin_Block_Editor {
     /**
      * Intercepts the post update and recompose the multi-language fields before being written in DB
      *
-     * @param WP_HTTP_Response $response
+     * @param WP_REST_Response|WP_HTTP_Response|WP_Error|mixed $response
      * @param array $handler
      * @param WP_REST_Request $request
      *
      * @return mixed
      */
-    public function rest_request_before_callbacks( $response, $handler, $request ) {
+    public function rest_request_before_callbacks( $response, array $handler, WP_REST_Request $request ) {
         if ( $request->get_method() !== 'PUT' && $request->get_method() !== 'POST' ) {
             return $response;
         }
@@ -142,7 +142,7 @@ class QTX_Admin_Block_Editor {
     /**
      * Restore the raw content of the post just updated and set the 'qtx_editor_lang', as for the prepare step
      *
-     * @param WP_HTTP_Response $response
+     * @param WP_REST_Response|WP_HTTP_Response|WP_Error|mixed $response
      * @param array $handler
      * @param WP_REST_Request $request
      *
@@ -166,7 +166,7 @@ class QTX_Admin_Block_Editor {
     /**
      * Enqueue the JS script
      */
-    public function enqueue_block_editor_assets() {
+    public function enqueue_block_editor_assets(): void {
         // By default, excluded post types are filtered out.
         global $q_config;
         $post_type          = qtranxf_post_type();
@@ -196,7 +196,7 @@ class QTX_Admin_Block_Editor {
      *
      * @return mixed
      */
-    private function select_raw_response_language( $response, $editor_lang ) {
+    private function select_raw_response_language( $response, string $editor_lang ) {
         $response_data = $response->get_data();
         if ( isset( $response_data['content'] ) && is_array( $response_data['content'] ) && isset( $response_data['content']['raw'] ) ) {
             $response_data['title']['raw']   = qtranxf_use( $editor_lang, $response_data['title']['raw'], false, true );

--- a/src/admin/i18n-interface-admin.php
+++ b/src/admin/i18n-interface-admin.php
@@ -17,5 +17,6 @@ interface WP_Translator_Admin extends WP_Translator {
      * @param (mixed)(optional) $term_default - The default term name to be encoded or null. It may be an array of terms.
      * @param (string)(optional) $taxonomy - Taxonomy name that $term is part of. Currently unused, since all term names assumed to be unique across all taxonomies.
      */
+    // TODO this function is never used (only in test and filter hook never triggered...), delete?
     public function multilingual_term( $term, $term_default = null, $taxonomy = null );
 }

--- a/src/admin/import_export.php
+++ b/src/admin/import_export.php
@@ -3,7 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-function qtranxf_migrate_options_update( $name_to, $name_from ) {
+function qtranxf_migrate_options_update( string $name_to, string $name_from ): void {
     global $wpdb;
     $option_names = $wpdb->get_col( "SELECT `option_name` FROM {$wpdb->options} WHERE `option_name` LIKE '$name_to\_%'" );
     foreach ( $option_names as $name ) {
@@ -19,7 +19,7 @@ function qtranxf_migrate_options_update( $name_to, $name_from ) {
     }
 }
 
-function qtranxf_migrate_options_copy( $name_to, $name_from ) {
+function qtranxf_migrate_options_copy( string $name_to, string $name_from ): void {
     global $wpdb;
     $options = $wpdb->get_results( "SELECT option_name, option_value FROM {$wpdb->options} WHERE `option_name` LIKE '$name_from\_%'" );
 
@@ -61,39 +61,39 @@ function qtranxf_migrate_options_copy( $name_to, $name_from ) {
     }
 }
 
-function qtranxf_migrate_import_mqtranslate() {
+function qtranxf_migrate_import_mqtranslate(): void {
     qtranxf_migrate_import( 'mqTranslate', 'mqtranslate' );
     update_option( 'qtranslate_qtrans_compatibility', '1' );//since 3.1
     $nm = '<strong>mqTranslate</strong>';
     qtranxf_add_warning( sprintf( __( 'Option "%s" has also been turned on, as the most common case for importing configuration from %s. You may turn it off manually if your setup does not require it. Refer to %sFAQ%s for more information.', 'qtranslate' ), __( 'Compatibility Functions', 'qtranslate' ), $nm, '<a href="https://github.com/qtranslate/qtranslate-xt/wiki/FAQ#compatibility-functions" target="_blank">', '</a>' ) );
 }
 
-function qtranxf_migrate_export_mqtranslate() {
+function qtranxf_migrate_export_mqtranslate(): void {
     qtranxf_migrate_export( 'mqTranslate', 'mqtranslate' );
 }
 
-function qtranxf_migrate_import_qtranslate_xp() {
+function qtranxf_migrate_import_qtranslate_xp(): void {
     qtranxf_migrate_import( 'qTranslate Plus', 'ppqtranslate' );
 }
 
-function qtranxf_migrate_export_qtranslate_xp() {
+function qtranxf_migrate_export_qtranslate_xp(): void {
     qtranxf_migrate_export( 'qTranslate Plus', 'ppqtranslate' );
 }
 
-function qtranxf_migrate_import( $plugin_name, $name_from ) {
+function qtranxf_migrate_import( string $plugin_name, string $name_from ): void {
     qtranxf_migrate_options_update( 'qtranslate', $name_from );
     $nm = '<strong>' . $plugin_name . '</strong>';
     qtranxf_add_warning( sprintf( __( 'Applicable options and taxonomy names from plugin %s have been imported. Note that the multilingual content of posts, pages and other objects has not been altered during this operation. There is no additional operation needed to import content, since its format is compatible with %s.', 'qtranslate' ), $nm, 'qTranslate&#8209;XT' ) . ' ' . sprintf( __( 'It might be a good idea to review %smigration instructions%s, if you have not yet done so.', 'qtranslate' ), '<a href="https://github.com/qtranslate/qtranslate-xt/wiki/Migration-Guide" target="_blank">', '</a>' ) );
     qtranxf_add_warning( sprintf( __( '%sImportant%s: Before you start making edits to post and pages, please, make sure that both, your front site and admin back-end, work under this configuration. It may help to review "%s" and see if any of conflicting plugins mentioned there are used here. While the current content, coming from %s, is compatible with this plugin, the newly modified posts and pages will be saved with a new square-bracket-only encoding, which has a number of advantages comparing to former %s encoding. However, the new encoding is not straightforwardly compatible with %s and you will need an additional step available under "%s" option if you ever decide to go back to %s. Even with this additional conversion step, the 3rd-party plugins custom-stored data will not be auto-converted, but manual editing will still work. That is why it is advisable to create a test-copy of your site before making any further changes. In case you encounter a problem, please give us a chance to improve %s, send the login information to the test-copy of your site to %s along with a detailed step-by-step description of what is not working, and continue using your main site with %s meanwhile. It would also help, if you share a success story as well, either on %sthe forum%s, or via the same e-mail as mentioned above. Thank you very much for trying %s.', 'qtranslate' ), '<strong>', '</strong>', '<a href="https://github.com/qtranslate/qtranslate-xt/issues" target="_blank">' . 'Known Issues' . '</a>', $nm, 'qTranslate', $nm, '<a href="https://github.com/qtranslate/qtranslate-xt/wiki/Migration-Guide#convert-database" target="_blank"><strong>' . __( 'Convert Database', 'qtranslate' ) . '</strong></a>', $nm, 'qTranslate&#8209;XT', '[no mail support]', $nm, '<a href="https://github.com/qTranslate/qtranslate-xt/issues">', '</a>', 'qTranslate&#8209;XT' ) . '<br/>' . __( 'This is a one-time message, which you will not see again, unless the same import is repeated.', 'qtranslate' ) );
 }
 
-function qtranxf_migrate_export( $plugin_name, $name_to ) {
+function qtranxf_migrate_export( string $plugin_name, string $name_to ): void {
     qtranxf_migrate_options_copy( $name_to, 'qtranslate' );
     $nm = '<strong>' . $plugin_name . '</strong>';
     qtranxf_add_message( sprintf( __( 'Applicable options have been exported to plugin %s. If you have done some post or page updates after migrating from %s, then "%s" operation is also required to convert the content to "dual language tag" style in order for plugin %s to function.', 'qtranslate' ), $nm, $nm, '<a href="https://github.com/qtranslate/qtranslate-xt/wiki/Migration-Guide/convert-database/" target="_blank"><strong>' . __( 'Convert Database', 'qtranslate' ) . '</strong></a>', $nm ) );
 }
 
-function qtranxf_migrate_plugins() {
+function qtranxf_migrate_plugins(): void {
     if ( ! current_user_can( 'manage_options' ) ) {
         return;
     }
@@ -121,7 +121,7 @@ function qtranxf_migrate_plugins() {
 
 add_action( 'qtranslate_save_config', 'qtranxf_migrate_plugins', 30 );
 
-function qtranxf_add_row_migrate( $nm, $plugin, $args = null ) {
+function qtranxf_add_row_migrate( string $nm, string $plugin, ?array $args = null ): void {
     if ( ! file_exists( WP_PLUGIN_DIR . '/' . $plugin ) && ! file_exists( WPMU_PLUGIN_DIR . '/' . $plugin ) ) {
         return;
     }
@@ -168,7 +168,7 @@ function qtranxf_add_row_migrate( $nm, $plugin, $args = null ) {
     <?php
 }
 
-function qtranxf_admin_section_import_export( $request_uri ) {
+function qtranxf_admin_section_import_export( string $request_uri ): void {
     global $q_config;
 
     QTX_Admin_Settings::open_section( 'import' );

--- a/src/admin/languages.php
+++ b/src/admin/languages.php
@@ -8,14 +8,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Load array of stored in options language properties
  * @since 3.3
  */
-function qtranxf_load_languages( &$cfg ) {
+function qtranxf_load_languages( array &$cfg ): void {
     global $qtranslate_options;
     //$cfg = array();
     foreach ( $qtranslate_options['languages'] as $name => $opn ) {
         $cfg[ $name ] = get_option( $opn, array() );
     }
-
-    return $cfg;
 }
 
 // function qtranxf_save_languages($cfg) is in activation_hook.php as it is in use there
@@ -24,7 +22,7 @@ function qtranxf_load_languages( &$cfg ) {
  * Remove language $lang properties from hash $langs.
  * @since 3.3
  */
-function qtranxf_unsetLanguage( &$langs, $lang ) {
+function qtranxf_unsetLanguage( array &$langs, string $lang ): void {
     unset( $langs['language_name'][ $lang ] );
     unset( $langs['flag'][ $lang ] );
     unset( $langs['locale'][ $lang ] );
@@ -38,7 +36,7 @@ function qtranxf_unsetLanguage( &$langs, $lang ) {
 /**
  * @since 3.4.2
  */
-function qtranxf_setLanguageAdmin( $lang ) {
+function qtranxf_setLanguageAdmin( string $lang ): void {
     global $q_config;
 
     $q_config['language'] = $lang;
@@ -49,7 +47,7 @@ function qtranxf_setLanguageAdmin( $lang ) {
  * Remove language $lang properties from hash $langs.
  * @since 3.3
  */
-function qtranxf_copyLanguage( &$langs, $cfg, $lang ) {
+function qtranxf_copyLanguage( array &$langs, array $cfg, string $lang ): void {
     $langs['language_name'][ $lang ] = $cfg['language_name'][ $lang ];
     $langs['flag'][ $lang ]          = $cfg['flag'][ $lang ];
     $langs['locale'][ $lang ]        = $cfg['locale'][ $lang ];
@@ -63,7 +61,7 @@ function qtranxf_copyLanguage( &$langs, $cfg, $lang ) {
     $langs['not_available'][ $lang ] = $cfg['not_available'][ $lang ];
 }
 
-function qtranxf_update_config_header_css() {
+function qtranxf_update_config_header_css(): void {
     global $q_config;
 
     $header_css = get_option( 'qtranslate_header_css' );
@@ -75,7 +73,7 @@ function qtranxf_update_config_header_css() {
     }
 }
 
-function qtranxf_disableLanguage( $lang ) {
+function qtranxf_disableLanguage( string $lang ): bool {
     global $q_config;
 
     if ( ! qtranxf_isEnabled( $lang ) ) {
@@ -97,7 +95,7 @@ function qtranxf_disableLanguage( $lang ) {
     return true;
 }
 
-function qtranxf_enableLanguage( $lang ) {
+function qtranxf_enableLanguage( string $lang ): bool {
     global $q_config;
 
     if ( qtranxf_isEnabled( $lang ) ) {
@@ -120,7 +118,7 @@ function qtranxf_enableLanguage( $lang ) {
  * Remove language $lang from the database.
  * @since 3.3
  */
-function qtranxf_deleteLanguage( $lang ) {
+function qtranxf_deleteLanguage( string $lang ): string {
     global $q_config;
 
     if ( ! qtranxf_language_predefined( $lang ) ) {

--- a/src/admin/update_gettext_db.php
+++ b/src/admin/update_gettext_db.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * or 0, if all languages were updated successfully,
  * or positive integer number of errors occurred on languages update.
  */
-function qtranxf_update_gettext_databases_ex( $force = false, $only_for_language = '' ) {
+function qtranxf_update_gettext_databases_ex( bool $force = false, string $only_for_language = '' ) {
     global $q_config;
 
     if ( $only_for_language && ! qtranxf_isEnabled( $only_for_language ) ) {

--- a/src/admin/user_options.php
+++ b/src/admin/user_options.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 add_action( 'show_user_profile', 'qtranxf_show_extra_profile_fields' );
 add_action( 'edit_user_profile', 'qtranxf_show_extra_profile_fields' );
 
-function qtranxf_show_extra_profile_fields( $user ) {
+function qtranxf_show_extra_profile_fields( WP_User $user ): void {
     global $q_config;
     if ( $q_config['highlight_mode'] != QTX_HIGHLIGHT_MODE_NONE ) { ?>
         <h3><?php _e( 'Translation options', 'qtranslate' ) ?></h3>
@@ -31,11 +31,11 @@ function qtranxf_show_extra_profile_fields( $user ) {
 add_action( 'personal_options_update', 'qtranxf_save_extra_profile_fields' );
 add_action( 'edit_user_profile_update', 'qtranxf_save_extra_profile_fields' );
 
-function qtranxf_save_extra_profile_fields( $user_id ) {
+function qtranxf_save_extra_profile_fields( int $user_id ): void {
     global $q_config;
 
     if ( ! current_user_can( 'edit_user', $user_id ) ) {
-        return false;
+        return;
     }
 
     if ( $q_config['highlight_mode'] != QTX_HIGHLIGHT_MODE_NONE ) {
@@ -46,6 +46,4 @@ function qtranxf_save_extra_profile_fields( $user_id ) {
             update_user_meta( $user_id, 'qtranslate_highlight_disabled', true );
         }
     }
-
-    return true;
 }

--- a/src/class_translator.php
+++ b/src/class_translator.php
@@ -27,13 +27,13 @@ class QTX_Translator implements WP_Translator {
         return $q_config['translator'];
     }
 
-    public function get_language() {
+    public function get_language(): string {
         global $q_config;
 
         return $q_config['language'];
     }
 
-    public function set_language( $lang ) {
+    public function set_language( string $lang ): string {
         global $q_config;
         $lang_curr = $q_config['language'];
         if ( qtranxf_isEnabled( $lang ) ) {
@@ -43,7 +43,7 @@ class QTX_Translator implements WP_Translator {
         return $lang_curr;
     }
 
-    public function translate_text( $text, $lang = null, $flags = 0 ) {
+    public function translate_text( $text, ?string $lang = null, int $flags = 0 ): string {
         global $q_config;
         if ( ! $lang ) {
             $lang = $q_config['language'];
@@ -54,7 +54,7 @@ class QTX_Translator implements WP_Translator {
         return qtranxf_use( $lang, $text, $show_available, $show_empty );
     }
 
-    public function translate_term( $term, $lang = null, $taxonomy = null ) {
+    public function translate_term( $term, ?string $lang = null, ?string $taxonomy = null ): string {
         global $q_config;
         if ( ! $lang ) {
             $lang = $q_config['language'];
@@ -63,7 +63,7 @@ class QTX_Translator implements WP_Translator {
         return qtranxf_term_use( $lang, $term, $taxonomy );
     }
 
-    public function translate_url( $url, $lang = null ) {
+    public function translate_url( $url, ?string $lang = null ): string {
         global $q_config;
         if ( $lang ) {
             $showLanguage = true;

--- a/src/compatibility.php
+++ b/src/compatibility.php
@@ -36,22 +36,22 @@ if ( ! function_exists( 'qtrans_getAvailableLanguages' ) ) {
 }
 
 if ( ! function_exists( 'qtrans_getLanguage' ) ) {
-    function qtrans_getLanguage() {
+    function qtrans_getLanguage(): string {
         return qtranxf_getLanguage();
     }
 }
 if ( ! function_exists( 'qtrans_getLanguageName' ) ) {
-    function qtrans_getLanguageName( $lang = '' ) {
+    function qtrans_getLanguageName( string $lang = '' ): string {
         return qtranxf_getLanguageNameNative( $lang );
     }
 }
 if ( ! function_exists( 'qtrans_getSortedLanguages' ) ) {
-    function qtrans_getSortedLanguages( $reverse = false ) {
+    function qtrans_getSortedLanguages( bool $reverse = false ): array {
         return qtranxf_getSortedLanguages( $reverse );
     }
 }
 if ( ! function_exists( 'qtrans_join' ) ) {
-    function qtrans_join( $texts ) {
+    function qtrans_join( $texts ): string {
         if ( ! is_array( $texts ) ) {
             $texts = qtranxf_split( $texts );
         }
@@ -60,12 +60,12 @@ if ( ! function_exists( 'qtrans_join' ) ) {
     }
 }
 if ( ! function_exists( 'qtrans_split' ) ) {
-    function qtrans_split( $text, $quicktags = true ) {
+    function qtrans_split( $text, bool $quicktags = true ): array {
         return qtranxf_split( $text );
     }
 }
 if ( ! function_exists( 'qtrans_use' ) ) {
-    function qtrans_use( $lang, $text, $show_available = false ) {
+    function qtrans_use( string $lang, $text, bool $show_available = false ) {
         return qtranxf_use( $lang, $text, $show_available );
     }
 }

--- a/src/date_time.php
+++ b/src/date_time.php
@@ -20,7 +20,7 @@
  * @todo Maybe deprecate. Avoid using this function, meant to transition from legacy strftime formats.
  * @see https://gist.github.com/bohwaz/42fc223031e2b2dd2585aab159a20f30 (for the original code).
  */
-function qxtranxf_intl_strftime( $format, $timestamp = null, $locale = null ) {
+function qxtranxf_intl_strftime( string $format, $timestamp = null, ?string $locale = null ): string {
     if ( null === $timestamp ) {
         $timestamp = new \DateTime;
     } elseif ( is_numeric( $timestamp ) ) {
@@ -48,7 +48,7 @@ function qxtranxf_intl_strftime( $format, $timestamp = null, $locale = null ) {
     ];
 
     // \DateTimeInterface, string
-    $intl_formatter = function ( $timestamp, $format ) use ( $intl_formats, $locale ) {
+    $intl_formatter = function ( DateTimeInterface $timestamp, string $format ) use ( $intl_formats, $locale ) {
         $tz        = $timestamp->getTimezone();
         $date_type = \IntlDateFormatter::FULL;
         $time_type = \IntlDateFormatter::FULL;
@@ -208,7 +208,7 @@ function qxtranxf_intl_strftime( $format, $timestamp = null, $locale = null ) {
  * @see https://www.php.net/manual/en/function.strftime.php
  * @see https://www.php.net/manual/en/datetime.format.php
  */
-function qtranxf_convert_date_format_to_strftime_format( $format ) {
+function qtranxf_convert_date_format_to_strftime_format( string $format ): string {
     $mappings = array(
         // day
         'd' => '%d',
@@ -280,7 +280,7 @@ function qtranxf_convert_date_format_to_strftime_format( $format ) {
  * @return string format in strftime
  * @todo Maybe deprecate. Don't use strftime formats anymore, since strftime is deprecated from PHP8.1.
  */
-function qtranxf_convert_to_strftime_format_using_config( $format, $default_format ) {
+function qtranxf_convert_to_strftime_format_using_config( string $format, string $default_format ): string {
     global $q_config;
     // If one of special language-neutral formats is requested, don't override it.
     switch ( $format ) {
@@ -316,7 +316,7 @@ function qtranxf_convert_to_strftime_format_using_config( $format, $default_form
  *
  * @return string
  */
-function qtranxf_get_language_date_or_time_format( $config_key ) {
+function qtranxf_get_language_date_or_time_format( string $config_key ): string {
     assert( $config_key == 'date_format' || $config_key == 'time_format' );
     global $q_config;
     if ( isset( $q_config[ $config_key ][ $q_config['language'] ] ) ) {
@@ -339,7 +339,7 @@ function qtranxf_get_language_date_or_time_format( $config_key ) {
  *
  * @return string date/time if the format is valid, default value otherwise.
  */
-function qtranxf_format_date( $format, $mysql_time, $default_value, $before = '', $after = '' ) {
+function qtranxf_format_date( string $format, string $mysql_time, string $default_value, string $before = '', string $after = '' ): string {
     if ( ! empty( $before ) || ! empty( $after ) ) {
         _deprecated_argument( __FUNCTION__, '3.13.0' );
     }
@@ -364,7 +364,7 @@ function qtranxf_format_date( $format, $mysql_time, $default_value, $before = ''
  *
  * @return string date/time if the format is valid, default value otherwise.
  */
-function qtranxf_format_time( $format, $mysql_time, $default_value, $before = '', $after = '' ) {
+function qtranxf_format_time( string $format, string $mysql_time, string $default_value, string $before = '', string $after = '' ): string {
     if ( ! empty( $before ) || ! empty( $after ) ) {
         _deprecated_argument( __FUNCTION__, '3.13.0' );
     }
@@ -379,7 +379,7 @@ function qtranxf_format_time( $format, $mysql_time, $default_value, $before = ''
 }
 
 // @see get_the_date
-function qtranxf_dateFromPostForCurrentLanguage( $old_date, $format = '', $post = null ) {
+function qtranxf_dateFromPostForCurrentLanguage( string $old_date, string $format = '', $post = null ): string {
     $post = get_post( $post );
     if ( ! $post ) {
         return $old_date;
@@ -389,7 +389,7 @@ function qtranxf_dateFromPostForCurrentLanguage( $old_date, $format = '', $post 
 }
 
 // @see get_the_modified_date
-function qtranxf_dateModifiedFromPostForCurrentLanguage( $old_date, $format = '' ) {
+function qtranxf_dateModifiedFromPostForCurrentLanguage( string $old_date, string $format = '' ): string {
     global $post;
     if ( ! $post ) {
         return $old_date;
@@ -399,7 +399,7 @@ function qtranxf_dateModifiedFromPostForCurrentLanguage( $old_date, $format = ''
 }
 
 // @see get_the_time
-function qtranxf_timeFromPostForCurrentLanguage( $old_date, $format = '', $post = null, $gmt = false ) {
+function qtranxf_timeFromPostForCurrentLanguage( string $old_date, string $format = '', $post = null, bool $gmt = false ): string {
     $post = get_post( $post );
     if ( ! $post ) {
         return $old_date;
@@ -410,7 +410,7 @@ function qtranxf_timeFromPostForCurrentLanguage( $old_date, $format = '', $post 
 }
 
 // @see get_post_modified_time
-function qtranxf_timeModifiedFromPostForCurrentLanguage( $old_date, $format = '', $gmt = false ) {
+function qtranxf_timeModifiedFromPostForCurrentLanguage( string $old_date, string $format = '', bool $gmt = false ): string {
     global $post;
     if ( ! $post ) {
         return $old_date;
@@ -421,7 +421,7 @@ function qtranxf_timeModifiedFromPostForCurrentLanguage( $old_date, $format = ''
 }
 
 // @see get_comment_date
-function qtranxf_dateFromCommentForCurrentLanguage( $old_date, $format, $comment = null ) {
+function qtranxf_dateFromCommentForCurrentLanguage( string $old_date, string $format, ?string $comment = null ): string {
     if ( ! $comment ) {
         global $comment;  // TODO drop obsolete compatibility with older WP
     }
@@ -433,7 +433,7 @@ function qtranxf_dateFromCommentForCurrentLanguage( $old_date, $format, $comment
 }
 
 // @see get_comment_time
-function qtranxf_timeFromCommentForCurrentLanguage( $old_date, $format = '', $gmt = false, $translate = true, $comment = null ) {
+function qtranxf_timeFromCommentForCurrentLanguage( string $old_date, string $format = '', bool $gmt = false, bool $translate = true, ?string $comment = null ): string {
     if ( ! $translate ) {
         return $old_date;
     }
@@ -453,7 +453,7 @@ function qtranxf_timeFromCommentForCurrentLanguage( $old_date, $format = '', $gm
  *
  * @return void
  */
-function qtranxf_add_date_time_filters() {
+function qtranxf_add_date_time_filters(): void {
     global $q_config;
 
     if ( $q_config['use_strftime'] != QTX_DATE_WP && class_exists( 'IntlDateFormatter' ) ) {

--- a/src/default_language_config.php
+++ b/src/default_language_config.php
@@ -4,7 +4,7 @@
  * Names for languages in the corresponding native language.
  * @since 3.3
  */
-function qtranxf_default_language_name() {
+function qtranxf_default_language_name(): array {
     return array(
         'en' => 'English',
         'zh' => '中文',   // 简体中
@@ -47,7 +47,7 @@ function qtranxf_default_language_name() {
  * Locales for languages, matching WordPress locales when possible.
  * @since 3.3
  */
-function qtranxf_default_locale() {
+function qtranxf_default_locale(): array {
     // see locale -a for available locales
     return array(
         'de' => 'de_DE',
@@ -91,7 +91,7 @@ function qtranxf_default_locale() {
  * HTML locales for languages
  * @since 3.4
  */
-function qtranxf_default_locale_html() {
+function qtranxf_default_locale_html(): array {
     //HTML locales for languages are not provided by default
     return array();
 }
@@ -100,7 +100,7 @@ function qtranxf_default_locale_html() {
  * Language not available messages
  * @since 3.3
  */
-function qtranxf_default_not_available() {
+function qtranxf_default_not_available(): array {
     // %LANG:<normal_separator>:<last_separator>% generates a list of languages separated by <normal_separator>
     // except for the last one, where <last_separator> will be used instead.
     // Not Available Message
@@ -149,7 +149,7 @@ function qtranxf_default_not_available() {
  * @todo Deprecate strftime format
  * @since 3.3
  */
-function qtranxf_default_date_format() {
+function qtranxf_default_date_format(): array {
     return array(
         'en' => '%A %B %e%q, %Y',
         'de' => '%A, \d\e\r %e. %B %Y',
@@ -193,7 +193,7 @@ function qtranxf_default_date_format() {
  * @todo Deprecate strftime format
  * @since 3.3
  */
-function qtranxf_default_time_format() {
+function qtranxf_default_time_format(): array {
     return array(
         'en' => '%I:%M %p',
         'de' => '%H:%M',
@@ -237,7 +237,7 @@ function qtranxf_default_time_format() {
  * Look in /flags/ directory for a huge list of flags for usage.
  * @since 3.3
  */
-function qtranxf_default_flag() {
+function qtranxf_default_flag(): array {
     return array(
         'en' => 'gb.png',
         'de' => 'de.png',
@@ -280,7 +280,7 @@ function qtranxf_default_flag() {
  * Full country names as locales for Windows systems, in English.
  * @since 3.3
  */
-function qtranxf_default_windows_locale() {
+function qtranxf_default_windows_locale(): array {
     return array(
         'aa' => "Afar",
         'ab' => "Abkhazian",

--- a/src/frontend.php
+++ b/src/frontend.php
@@ -27,7 +27,7 @@ function qtranxf_get_front_page_config() {
     return $page_configs;
 }
 
-function qtranxf_wp_head() {
+function qtranxf_wp_head(): void {
     global $q_config;
 
     if ( $q_config['header_css_on'] ) {
@@ -64,7 +64,7 @@ function qtranxf_wp_head() {
  * to remove this line from the header.
  * @since 3.4.5.4
  */
-function qtranxf_wp_head_meta_generator() {
+function qtranxf_wp_head_meta_generator(): void {
     echo '<meta name="generator" content="qTranslate-XT ' . QTX_VERSION . '" />' . PHP_EOL;
 }
 
@@ -655,7 +655,7 @@ function qtranxf_esc_html( $text ) {
 
 if ( ! function_exists( 'qtranxf_trim_words' ) ) {
 // filter added in qtranslate_hooks.php
-    function qtranxf_trim_words( $text, $num_words, $more, $original_text ) {
+    function qtranxf_trim_words( string $text, int $num_words, string $more, string $original_text ): string {
         global $q_config;
         $blocks = qtranxf_get_language_blocks( $original_text );
         if ( count( $blocks ) <= 1 ) {
@@ -673,7 +673,7 @@ if ( ! function_exists( 'qtranxf_trim_words' ) ) {
  * Delete translated post_meta cache for all languages.
  * Cache may have a few languages, if it is persistent.
  */
-function qtranxf_cache_delete_metadata( $meta_type, $object_id ) {//, $meta_key) {
+function qtranxf_cache_delete_metadata( string $meta_type, int $object_id ): void {
     global $q_config;
     // maybe optimized to only replace the meta_key needed ?
     foreach ( $q_config['enabled_languages'] as $lang ) {
@@ -686,7 +686,7 @@ function qtranxf_cache_delete_metadata( $meta_type, $object_id ) {//, $meta_key)
  * @since 3.2.3 translation of meta data
  * @since 3.4.6.4 improved caching algorithm
  */
-function qtranxf_translate_metadata( $meta_type, $original_value, $object_id, $meta_key = '', $single = false ) {
+function qtranxf_translate_metadata( string $meta_type, $original_value, int $object_id, string $meta_key = '', bool $single = false ) {
     global $q_config;
     static $meta_cache_unserialized = array();
     if ( ! isset( $q_config['url_info'] ) ) {
@@ -801,7 +801,7 @@ function qtranxf_translate_metadata( $meta_type, $original_value, $object_id, $m
 /**
  * @since 3.2.3 translation of postmeta
  */
-function qtranxf_filter_postmeta( $original_value, $object_id, $meta_key = '', $single = false ) {
+function qtranxf_filter_postmeta( $original_value, int $object_id, string $meta_key = '', bool $single = false ) {
     return qtranxf_translate_metadata( 'post', $original_value, $object_id, $meta_key, $single );
 }
 
@@ -810,7 +810,7 @@ function qtranxf_filter_postmeta( $original_value, $object_id, $meta_key = '', $
  * Delete translated post_meta cache for all languages on cache update.
  * Cache may have a few languages, if it is persistent.
  */
-function qtranxf_updated_postmeta( $meta_id, $object_id, $meta_key, $meta_value ) {
+function qtranxf_updated_postmeta( int $meta_id, int $object_id, string $meta_key, $meta_value ) {
     qtranxf_cache_delete_metadata( 'post', $object_id );
 }
 
@@ -818,7 +818,7 @@ function qtranxf_updated_postmeta( $meta_id, $object_id, $meta_key, $meta_value 
 /**
  * @since 3.4 translation of usermeta
  */
-function qtranxf_filter_usermeta( $original_value, $object_id, $meta_key = '', $single = false ) {
+function qtranxf_filter_usermeta( $original_value, int $object_id, string $meta_key = '', bool $single = false ) {
     return qtranxf_translate_metadata( 'user', $original_value, $object_id, $meta_key, $single );
 }
 
@@ -827,11 +827,12 @@ function qtranxf_filter_usermeta( $original_value, $object_id, $meta_key = '', $
  * Delete translated user_meta cache for all languages on cache update.
  * Cache may have a few languages, if it is persistent.
  */
-function qtranxf_updated_usermeta( $meta_id, $object_id, $meta_key, $meta_value ) {
+function qtranxf_updated_usermeta( int $meta_id, int $object_id, string $meta_key, $meta_value ) {
     qtranxf_cache_delete_metadata( 'user', $object_id );
 }
 
-function qtranxf_checkCanonical( $redirect_url, $requested_url ) {
+// TODO check API with Yoast, seems it's only 1 parameter?
+function qtranxf_checkCanonical( string $redirect_url, string $requested_url ): string {
     global $q_config;
     $lang = $q_config['language'];
     // fix canonical conflicts with language urls
@@ -843,7 +844,7 @@ function qtranxf_checkCanonical( $redirect_url, $requested_url ) {
 /**
  * @since 3.2.8 moved here from _hooks.php
  */
-function qtranxf_convertBlogInfoURL( $url, $what ) {
+function qtranxf_convertBlogInfoURL( string $url, string $what ): string {
     switch ( $what ) {
         case 'stylesheet_url':
         case 'template_url':
@@ -859,9 +860,10 @@ function qtranxf_convertBlogInfoURL( $url, $what ) {
  * @since 3.3.1
  * Moved here from qtranslate_hooks.php and modified.
  */
-function qtranxf_pagenum_link( $url ) {
+function qtranxf_pagenum_link( string $url ): string {
     $lang_code = QTX_LANG_CODE_FORMAT;
-    $url_fixed = preg_replace( "#\?lang=$lang_code/#i", '/', $url ); //kind of ugly fix for function get_pagenum_link in /wp-includes/link-template.php. Maybe we should cancel filter 'bloginfo_url' instead?
+    // TODO kind of ugly fix for function get_pagenum_link in /wp-includes/link-template.php. Maybe we should cancel filter 'bloginfo_url' instead?
+    $url_fixed = preg_replace( "#\?lang=$lang_code/#i", '/', $url );
 
     return qtranxf_convertURL( $url_fixed );
 }
@@ -869,7 +871,7 @@ function qtranxf_pagenum_link( $url ) {
 /**
  * @since 3.3.7
  */
-function qtranxf_add_front_filters() {
+function qtranxf_add_front_filters(): void {
     global $q_config;
 
     add_action( 'wp_head', 'qtranxf_wp_head' );

--- a/src/hooks.php
+++ b/src/hooks.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * locale for current language and set it on PHP.
  */
-function qtranxf_localeForCurrentLanguage( $locale ) {
+function qtranxf_localeForCurrentLanguage( string $locale ): string {
     static $locale_lang;
     if ( ! empty( $locale_lang ) ) {
         return $locale_lang;
@@ -72,11 +72,11 @@ function qtranxf_useDefaultLanguage( $content ) {
     return qtranxf_use( $q_config['default_language'], $content, false, false );
 }
 
-function qtranxf_versionLocale() {
+function qtranxf_versionLocale(): string {
     return 'en_US';
 }
 
-function qtranxf_useRawTitle( $title, $raw_title = '', $context = 'save' ) {
+function qtranxf_useRawTitle( string $title, string $raw_title = '', string $context = 'save' ): string {
     switch ( $context ) {
         case 'save':
             {
@@ -120,7 +120,7 @@ function qtranxf_ngettext( $translated_text ) {
  *
  * @return void
  */
-function qtranxf_add_main_filters() {
+function qtranxf_add_main_filters(): void {
     add_filter( 'wp_trim_words', 'qtranxf_trim_words', 0, 4 );
     add_filter( 'sanitize_title', 'qtranxf_useRawTitle', 0, 3 );
     add_filter( 'comment_moderation_subject', 'qtranxf_useDefaultLanguage', 0 );

--- a/src/i18n-interface.php
+++ b/src/i18n-interface.php
@@ -55,7 +55,7 @@ interface WP_Translator {
      * @return string two-letter code of active language.
      * @since 3.4.6.9
      */
-    public function get_language();
+    public function get_language(): string;
 
     /**
      * @param string $lang two-letter code of language to be set as active. Further translations will be to this language unless desired languge is specified.
@@ -64,7 +64,7 @@ interface WP_Translator {
      * @since 3.4.6.9
      *
      */
-    public function set_language( $lang );
+    public function set_language( string $lang ): string;
 
     /**
      * Get translated value from a multilingual string.
@@ -76,7 +76,7 @@ interface WP_Translator {
      *     TRANSLATE_SHOW_AVALABLE - return a list of available languages with language-encoded links to the current page.
      *     TRANSLATE_SHOW_EMPTY - return empty string.
      */
-    public function translate_text( $text, $lang = null, $flags = 0 );
+    public function translate_text( $text, ?string $lang = null, int $flags = 0 ): string;
 
     /**
      * Get translated value for a term name.
@@ -85,7 +85,7 @@ interface WP_Translator {
      * @param (string)(optional) $lang - A two-letter language code of the language to translate $term to. If omitted or null, then the currently active language is assumed.
      * @param (string)(optional) $taxonomy - Taxonomy name that $term is part of. Currently unused, since all term names assumed to be unique across all taxonomies.
      */
-    public function translate_term( $term, $lang = null, $taxonomy = null );
+    public function translate_term( $term, ?string $lang = null, ?string $taxonomy = null ): string;
 
     /**
      * Get language-encoded value for a URL.
@@ -93,6 +93,6 @@ interface WP_Translator {
      * @param (mixed) $url - The URL to be encoded. It may be an array of URLs.
      * @param (string)(optional) $lang - A two-letter language code of the language to encode $url with. If omitted or null, then the currently active language is assumed.
      */
-    public function translate_url( $url, $lang = null );
+    public function translate_url( $url, ?string $lang = null ): string;
 
 }

--- a/src/init.php
+++ b/src/init.php
@@ -23,7 +23,7 @@ require_once QTRANSLATE_DIR . '/src/modules/module_loader.php';
  *
  * @return void
  */
-function qtranxf_init_language() {
+function qtranxf_init_language(): void {
     global $q_config, $pagenow;
 
     qtranxf_load_config();

--- a/src/language_blocks.php
+++ b/src/language_blocks.php
@@ -35,7 +35,7 @@ function qtranxf_get_language_blocks( $text ) {
  *
  * @return string[] array of string items indexed by language.
  */
-function qtranxf_split( $text ) {
+function qtranxf_split( $text ): array {
     $blocks = qtranxf_get_language_blocks( $text );
 
     return qtranxf_split_blocks( $blocks );
@@ -50,7 +50,7 @@ function qtranxf_split( $text ) {
  * @return string[] array of string items indexed by language.
  * @since 3.4.5.2 $found added
  */
-function qtranxf_split_blocks( $blocks, &$found = array() ) {
+function qtranxf_split_blocks( array $blocks, array &$found = array() ): array {
     global $q_config;
 
     $result = array();
@@ -109,7 +109,7 @@ function qtranxf_split_blocks( $blocks, &$found = array() ) {
 /**
  * gets only part with encoded languages
  */
-function qtranxf_split_languages( $blocks ) {
+function qtranxf_split_languages( array $blocks ): array {
     $result           = array();
     $current_language = false;
     $lang_code        = QTX_LANG_CODE_FORMAT;
@@ -177,7 +177,7 @@ function qtranxf_getAvailableLanguages( $text ) {
     return $result;
 }
 
-function qtranxf_allthesame( $texts ) {
+function qtranxf_allthesame( array $texts ): ?string {
     $text = null;
     // take first not empty
     foreach ( $texts as $lang => $lang_text ) {
@@ -199,7 +199,7 @@ function qtranxf_allthesame( $texts ) {
     return $text;
 }
 
-function qtranxf_join_c( $texts ) {
+function qtranxf_join_c( array $texts ): string {
     $text = qtranxf_allthesame( $texts );
     if ( ! is_null( $text ) ) {
         return $text;
@@ -215,7 +215,7 @@ function qtranxf_join_c( $texts ) {
     return $text;
 }
 
-function qtranxf_join_b_no_closing( $texts ) {
+function qtranxf_join_b_no_closing( array $texts ): string {
     $text = qtranxf_allthesame( $texts );
     if ( ! is_null( $text ) ) {
         return $text;
@@ -231,7 +231,7 @@ function qtranxf_join_b_no_closing( $texts ) {
     return $text;
 }
 
-function qtranxf_join_b( $texts ) {
+function qtranxf_join_b( array $texts ): string {
     $text = qtranxf_allthesame( $texts );
     if ( ! is_null( $text ) ) {
         return $text;
@@ -253,7 +253,7 @@ function qtranxf_join_b( $texts ) {
 /**
  * @since 3.3.6 swirly bracket encoding
  */
-function qtranxf_join_s( $texts ) {
+function qtranxf_join_s( array $texts ): string {
     $text = qtranxf_allthesame( $texts );
     if ( ! is_null( $text ) ) {
         return $text;
@@ -276,7 +276,7 @@ function qtranxf_join_s( $texts ) {
  * Prepares multilingual text leaving text that matches $regex_sep outside of language tags.
  * @since 3.4.6.2
  */
-function qtranxf_join_byseparator( $texts, $regex_sep ) {
+function qtranxf_join_byseparator( array $texts, string $regex_sep ): string {
     $text = qtranxf_allthesame( $texts );
     if ( ! is_null( $text ) ) {
         return $text;
@@ -316,7 +316,7 @@ function qtranxf_join_byseparator( $texts, $regex_sep ) {
 /**
  * Prepare multilingal text leaving new line outside of language tags '[:]'.
  */
-function qtranxf_join_byline( $texts ) {
+function qtranxf_join_byline( array $texts ): string {
     $text = qtranxf_allthesame( $texts );
     if ( ! is_null( $text ) ) {
         return $text;
@@ -351,7 +351,8 @@ function qtranxf_join_byline( $texts ) {
     return $text;
 }
 
-function qtranxf_use( $lang, $text, $show_available = false, $show_empty = false ) {
+// TODO: this function signature is way too generic and weakly typed, break it by input type.
+function qtranxf_use( string $lang, $text, bool $show_available = false, bool $show_empty = false ) {
     // return full string if language is not enabled
     if ( is_array( $text ) ) {
         // handle arrays recursively
@@ -382,7 +383,7 @@ function qtranxf_use( $lang, $text, $show_available = false, $show_empty = false
 }
 
 /** when $text is already known to be string */
-function qtranxf_use_language( $lang, $text, $show_available = false, $show_empty = false ) {
+function qtranxf_use_language( string $lang, string $text, bool $show_available = false, bool $show_empty = false ) {
     $blocks = qtranxf_get_language_blocks( $text );
     if ( count( $blocks ) <= 1 )//no language is encoded in the $text, the most frequent case
     {
@@ -392,14 +393,14 @@ function qtranxf_use_language( $lang, $text, $show_available = false, $show_empt
     return qtranxf_use_block( $lang, $blocks, $show_available, $show_empty );
 }
 
-function qtranxf_use_block( $lang, $blocks, $show_available = false, $show_empty = false ) {
+function qtranxf_use_block( string $lang, array $blocks, bool $show_available = false, bool $show_empty = false ): string {
     $available_langs = array();
     $content         = qtranxf_split_blocks( $blocks, $available_langs );
 
     return qtranxf_use_content( $lang, $content, $available_langs, $show_available, $show_empty );
 }
 
-function qtranxf_use_content( $lang, $content, $available_langs, $show_available = false, $show_empty = false ) {
+function qtranxf_use_content( string $lang, $content, array $available_langs, bool $show_available = false, bool $show_empty = false ): string {
     global $q_config;
     // show the content in the requested language, if available
     if ( ! empty( $available_langs[ $lang ] ) ) {
@@ -461,7 +462,7 @@ function qtranxf_use_content( $lang, $content, $available_langs, $show_available
     return apply_filters( 'i18n_content_translation_not_available', $output, $lang, $language_list, $alt_lang, $alt_content, $msg, $q_config );
 }
 
-function qtranxf_showAllSeparated( $text ) {
+function qtranxf_showAllSeparated( $text ): string {
     if ( empty( $text ) ) {
         return $text;
     }

--- a/src/language_config.php
+++ b/src/language_config.php
@@ -1,12 +1,12 @@
 <?php
 
-function qtranxf_getLanguage() {
+function qtranxf_getLanguage(): string {
     global $q_config;
 
     return $q_config['language'];
 }
 
-function qtranxf_getLanguageDefault() {
+function qtranxf_getLanguageDefault(): string {
     global $q_config;
 
     return $q_config['default_language'];
@@ -15,7 +15,7 @@ function qtranxf_getLanguageDefault() {
 /**
  * @since 3.4.5.4 - return language name in native language, former qtranxf_getLanguageName.
  */
-function qtranxf_getLanguageNameNative( $lang = '' ) {
+function qtranxf_getLanguageNameNative( string $lang = '' ): string {
     global $q_config;
     if ( empty( $lang ) ) {
         $lang = $q_config['language'];
@@ -27,7 +27,7 @@ function qtranxf_getLanguageNameNative( $lang = '' ) {
 /**
  * @since 3.4.5.4 - return language name in active language, if available, otherwise the name in native language.
  */
-function qtranxf_getLanguageName( $lang = '' ) {
+function qtranxf_getLanguageName( string $lang = '' ): string {
     global $q_config, $l10n;
     if ( empty( $lang ) ) {
         return $q_config['language_name'][ $q_config['language'] ];
@@ -74,14 +74,14 @@ function qtranxf_getLanguageName( $lang = '' ) {
     return $q_config['language-names'][ $lang ] = $n;
 }
 
-function qtranxf_isEnabled( $lang ) {
+function qtranxf_isEnabled( string $lang ): bool {
     global $q_config;
 
     // only available languages are loaded, works quicker
     return isset( $q_config['locale'][ $lang ] );
 }
 
-function qtranxf_getSortedLanguages( $reverse = false ) {
+function qtranxf_getSortedLanguages( bool $reverse = false ): array {
     global $q_config;
     $languages = $q_config['enabled_languages'];
     ksort( $languages );

--- a/src/language_detect.php
+++ b/src/language_detect.php
@@ -1,6 +1,6 @@
 <?php
 
-function qtranxf_detect_language( &$url_info ) {
+function qtranxf_detect_language( array &$url_info ) {
     global $q_config;
 
     if ( is_admin() || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
@@ -100,7 +100,7 @@ function qtranxf_detect_language( &$url_info ) {
     return $lang;
 }
 
-function qtranxf_resolveLangCase( $lang, &$caseredirect ) {
+function qtranxf_resolveLangCase( string $lang, ?bool &$caseredirect ): string {
     if ( qtranxf_isEnabled( $lang ) ) {
         return $lang;
     }
@@ -134,7 +134,7 @@ function qtranxf_resolveLangCase( $lang, &$caseredirect ) {
  *
  * @return bool|string
  */
-function qtranxf_parse_language_info( &$url_info, $link = false ) {
+function qtranxf_parse_language_info( array &$url_info, bool $link = false ) {
     global $q_config;
 
     qtranxf_complete_url_info_path( $url_info );
@@ -293,14 +293,14 @@ function qtranxf_parse_language_info( &$url_info, $link = false ) {
     return $parsed_lang;
 }
 
-function qtranxf_detect_language_admin( &$url_info ) {
+function qtranxf_detect_language_admin( array &$url_info ): string {
     require_once QTRANSLATE_DIR . '/src/admin/admin_utils.php';
     $url_info = apply_filters( 'qtranslate_detect_admin_language', $url_info );
 
     return $url_info['lang_admin'];
 }
 
-function qtranxf_detect_language_front( &$url_info ) {
+function qtranxf_detect_language_front( array &$url_info ): string {
     global $q_config;
 
     $lang = null;
@@ -333,7 +333,7 @@ function qtranxf_detect_language_front( &$url_info ) {
     return $lang;
 }
 
-function qtranxf_setcookie_language( $lang, $cookie_name, $cookie_path ) {
+function qtranxf_setcookie_language( string $lang, string $cookie_name, string $cookie_path ): void {
     global $q_config;
 
     // Sometimes wp_cron.php SEEMS to be the source of headers being sent prematurely.
@@ -356,7 +356,7 @@ function qtranxf_setcookie_language( $lang, $cookie_name, $cookie_path ) {
     }
 }
 
-function qtranxf_set_language_cookie( $lang ) {
+function qtranxf_set_language_cookie( string $lang ): void {
     global $q_config;
 
     assert( ! qtranxf_is_rest_request_expected() );
@@ -367,7 +367,7 @@ function qtranxf_set_language_cookie( $lang ) {
     }
 }
 
-function qtranxf_get_browser_language() {
+function qtranxf_get_browser_language(): ?string {
     if ( ! isset( $_SERVER["HTTP_ACCEPT_LANGUAGE"] ) ) {
         return null;
     }
@@ -396,7 +396,7 @@ function qtranxf_get_browser_language() {
     return null;
 }
 
-function qtranxf_http_negotiate_language() {
+function qtranxf_http_negotiate_language(): ?string {
     global $q_config;
     if ( function_exists( 'http_negotiate_language' ) ) {
         $default_language = $q_config['default_language'];

--- a/src/modules/acf/admin.php
+++ b/src/modules/acf/admin.php
@@ -22,7 +22,7 @@ class QTX_Module_Acf_Admin {
      * Return the standard ACF fields (built-in) supported for content translation e.g. post or page.
      * @return string[]
      */
-    public static function standard_fields() {
+    public static function standard_fields(): array {
         return [
             'text',
             'textarea',
@@ -34,7 +34,7 @@ class QTX_Module_Acf_Admin {
      * Return the sub-fields (built-in) supported in group settings, with their labels.
      * @return array string ID => string label
      */
-    public static function group_sub_fields() {
+    public static function group_sub_fields(): array {
         return [
             'label'         => __( 'Label', 'acf' ),
             'instructions'  => __( 'Instructions', 'acf' ),
@@ -46,7 +46,7 @@ class QTX_Module_Acf_Admin {
      * Return the qtranslate fields e.g. post or page.
      * @return array
      */
-    public static function qtranslate_fields() {
+    public static function qtranslate_fields(): array {
         return [
             'qtranslate_file',
             'qtranslate_image',
@@ -65,7 +65,7 @@ class QTX_Module_Acf_Admin {
      *
      * @return array
      */
-    public function get_field_types( $groups ) {
+    public function get_field_types( array $groups ): array {
         if ( ! isset ( $groups[ QTX_Module_Acf_Extended::ACF_CATEGORY_QTX ] ) ) {
             return $groups;
         }
@@ -90,7 +90,7 @@ class QTX_Module_Acf_Admin {
     /**
      * Load javascript and stylesheets on admin pages
      */
-    public function admin_enqueue_scripts() {
+    public function admin_enqueue_scripts(): void {
         wp_enqueue_style( 'qtranslate-acf', plugins_url( 'css/modules/acf.css', QTRANSLATE_FILE ),
             array( 'acf-input' ), QTX_VERSION );
 
@@ -106,7 +106,7 @@ class QTX_Module_Acf_Admin {
     /**
      * Add additional styles and scripts to head
      */
-    public function admin_head() {
+    public function admin_head(): void {
         // Hide the language tabs if they shouldn't be displayed
         $show_language_tabs = self::get_module_setting( 'show_language_tabs' );
         if ( ! $show_language_tabs ) {
@@ -131,7 +131,7 @@ class QTX_Module_Acf_Admin {
      *
      * @return array
      */
-    public function filter_qtranslate_admin_config( $config ) {
+    public function filter_qtranslate_admin_config( array $config ): array {
         // Display for posts with ACF fields.
         $config['acf-post'] = [
             'pages' => [
@@ -240,7 +240,7 @@ class QTX_Module_Acf_Admin {
      *
      * @return mixed
      */
-    protected static function get_module_setting( $name, $default = null ) {
+    protected static function get_module_setting( string $name, $default = null ) {
         $options = get_option( QTX_OPTIONS_MODULE_ACF );
         if ( isset( $options[ $name ] ) ) {
             return $options[ $name ];
@@ -252,7 +252,7 @@ class QTX_Module_Acf_Admin {
     /**
      * Register settings and validation hooks.
      */
-    public function admin_init() {
+    public function admin_init(): void {
         register_setting( 'settings-qtranslate-acf', QTX_OPTIONS_MODULE_ACF );
 
         // Standard fields (ACF builtin fields)
@@ -325,7 +325,7 @@ class QTX_Module_Acf_Admin {
      * @return bool|string
      * @see acf_validation::acf_validate_value
      */
-    public static function validate_raw_value_standard( $valid, $value, $field, $input ) {
+    public static function validate_raw_value_standard( $valid, $value, array $field, $input ) {
         if ( is_string( $value ) && qtranxf_isMultilingual( $value ) ) {
             // Remove the standard validation that is likely to fail for the raw value.
             $instance = acf_get_field_type( $field['type'] );
@@ -353,7 +353,7 @@ class QTX_Module_Acf_Admin {
      * @return    bool|string
      * @see acf_validation::acf_validate_value
      */
-    protected static function validate_language_values_standard( $field_object, $valid, $values, $field, $input ) {
+    protected static function validate_language_values_standard( $field_object, $valid, array $values, array $field, $input ) {
         global $q_config;
 
         // Validate every language value as string.
@@ -381,14 +381,14 @@ class QTX_Module_Acf_Admin {
         return $valid;
     }
 
-    public function display_settings() {
+    public function display_settings(): void {
         QTX_Admin_Settings::open_section( 'acf' );
         wp_nonce_field( 'acf', 'nonce_acf', false );
         do_settings_sections( 'settings-qtranslate-acf' );
         QTX_Admin_Settings::close_section( 'acf' );
     }
 
-    public function update_settings() {
+    public function update_settings(): void {
         // The nonce allows to validate the settings tab was displayed but also to have checkbox fields only.
         if ( ! isset( $_POST['nonce_acf'] ) || ! wp_verify_nonce( $_POST['nonce_acf'], 'acf' ) ) {
             return;
@@ -400,7 +400,7 @@ class QTX_Module_Acf_Admin {
     /**
      * Render setting
      */
-    public function render_setting_standard_fields() {
+    public function render_setting_standard_fields(): void {
         $fields   = self::standard_fields();
         $default  = array_fill_keys( $fields, true );
         $settings = self::get_module_setting( 'standard_fields', $default );
@@ -421,7 +421,7 @@ class QTX_Module_Acf_Admin {
     /**
      * Render setting
      */
-    public function render_setting_group_sub_fields() {
+    public function render_setting_group_sub_fields(): void {
         $fields   = self::group_sub_fields();
         $default  = array_fill_keys( array_keys( $fields ), true );
         $settings = self::get_module_setting( 'group_sub_fields', $default );
@@ -438,7 +438,7 @@ class QTX_Module_Acf_Admin {
     /**
      * Render setting
      */
-    public function render_setting_qtranslate_fields() {
+    public function render_setting_qtranslate_fields(): void {
         $fields   = self::qtranslate_fields();
         $default  = array_fill_keys( array_keys( $fields ), false );
         $settings = self::get_module_setting( 'qtranslate_fields', $default );
@@ -460,7 +460,7 @@ class QTX_Module_Acf_Admin {
     /**
      * Render setting
      */
-    public function render_setting_show_language_tabs() {
+    public function render_setting_show_language_tabs(): void {
         ?>
         <input type="checkbox"
                name="<?php echo QTX_OPTIONS_MODULE_ACF ?>[show_language_tabs]" <?php checked( self::get_module_setting( 'show_language_tabs', false ), 1 ); ?>

--- a/src/modules/acf/extended.php
+++ b/src/modules/acf/extended.php
@@ -21,7 +21,7 @@ class QTX_Module_Acf_Extended {
     /**
      * Register the fields in the ACF plugin.
      */
-    public function include_fields() {
+    public function include_fields(): void {
         require_once __DIR__ . '/fields/file.php';
         require_once __DIR__ . '/fields/image.php';
         require_once __DIR__ . '/fields/post_object.php';
@@ -45,7 +45,7 @@ class QTX_Module_Acf_Extended {
      * This filter is applied to the $value after it is loaded from the db and
      * before it is returned to the template via functions such as get_field().
      *
-     * @param $value
+     * @param mixed $value
      *
      * @return array|mixed|string|void
      */
@@ -65,20 +65,18 @@ class QTX_Module_Acf_Extended {
      *
      * @return string
      */
-    public static function encode_language_values( $values ) {
-        assert( is_array( $values ) );
-
+    public static function encode_language_values( array $values ): string {
         return qtranxf_join_b( $values );
     }
 
     /**
      * Decode a multi-language string to an array
      *
-     * @param string $values
+     * @param string|null $values
      *
      * @return array
      */
-    public static function decode_language_values( $values ) {
+    public static function decode_language_values( ?string $values ): array {
         return qtranxf_split( $values );
     }
 
@@ -98,7 +96,7 @@ class QTX_Module_Acf_Extended {
      * @return    bool|string
      * @see acf_validation::acf_validate_value
      */
-    public static function validate_language_values( $field_object, $valid, $values, $field, $input ) {
+    public static function validate_language_values( $field_object, $valid, array $values, array $field, $input ) {
         global $q_config;
 
         // retrieve the original ACF validation method for that field (cumbersome, but we can't change acf_field base class)

--- a/src/modules/acf/loader.php
+++ b/src/modules/acf/loader.php
@@ -10,7 +10,7 @@
  *
  * @return void
  */
-function qtranxf_acf_init() {
+function qtranxf_acf_init(): void {
     static $acf_loaded = false;
 
     if ( ! $acf_loaded && function_exists( 'acf' ) ) {

--- a/src/modules/admin_module.php
+++ b/src/modules/admin_module.php
@@ -44,7 +44,7 @@ class QTX_Admin_Module {
      *
      * @see QTX_Admin_Module
      */
-    function __construct( $fields ) {
+    function __construct( array $fields ) {
         $this->id           = $fields['id'];
         $this->name         = $fields['name'];
         $this->plugins      = $fields['plugins'] ?? array();
@@ -57,7 +57,7 @@ class QTX_Admin_Module {
      *
      * @return bool
      */
-    function is_default_enabled() {
+    function is_default_enabled(): bool {
         return ! empty( $this->plugins );
     }
 
@@ -73,7 +73,7 @@ class QTX_Admin_Module {
      *
      * @return array[] ordered by module name
      */
-    protected static function get_builtin_setup() {
+    protected static function get_builtin_setup(): array {
         return [
             [
                 'id'           => 'acf',
@@ -139,7 +139,7 @@ class QTX_Admin_Module {
      *
      * @return QTX_Admin_Module[] ordered by name
      */
-    public static function get_modules() {
+    public static function get_modules(): array {
         static $modules;
         if ( isset( $modules ) ) {
             return $modules;

--- a/src/modules/admin_module_manager.php
+++ b/src/modules/admin_module_manager.php
@@ -10,7 +10,7 @@ class QTX_Admin_Module_Manager {
     /**
      * Register hooks for modules and related plugins
      */
-    public static function register_hooks() {
+    public static function register_hooks(): void {
         add_action( 'admin_notices', 'QTX_Admin_Module_Manager::admin_notices' );
         add_action( 'activated_plugin', 'QTX_Admin_Module_Manager::register_plugin_activated' );
         add_action( 'deactivated_plugin', 'QTX_Admin_Module_Manager::register_plugin_deactivated' );
@@ -29,7 +29,7 @@ class QTX_Admin_Module_Manager {
      *
      * @param callable $func_is_active callback to evaluate if a plugin is active
      */
-    public static function update_modules_state( $func_is_active = 'is_plugin_active' ) {
+    public static function update_modules_state( $func_is_active = 'is_plugin_active' ): void {
         global $q_config;
 
         $option_modules = array();
@@ -63,7 +63,7 @@ class QTX_Admin_Module_Manager {
      *
      * @return bool true if the integration plugin is active OR if the module does not have any.
      */
-    public static function is_module_plugin_active( $module, $func_is_active = 'is_plugin_active' ) {
+    public static function is_module_plugin_active( QTX_Admin_Module $module, $func_is_active = 'is_plugin_active' ): bool {
         if ( empty( $module->plugins ) ) {
             return true; // Attention: should not be interpreted as "having a plugin".
         }
@@ -91,7 +91,7 @@ class QTX_Admin_Module_Manager {
      *
      * @return integer module state
      */
-    public static function can_module_be_activated( $module, $func_is_active = 'is_plugin_active' ) {
+    public static function can_module_be_activated( QTX_Admin_Module $module, $func_is_active = 'is_plugin_active' ): int {
         $state = QTX_MODULE_STATE_INACTIVE;
 
         if ( self::is_module_plugin_active( $module, $func_is_active ) ) {
@@ -110,7 +110,7 @@ class QTX_Admin_Module_Manager {
      *
      * @param string $activated_plugin name of the plugin being activated.
      */
-    public static function register_plugin_activated( $activated_plugin ) {
+    public static function register_plugin_activated( string $activated_plugin ): void {
         // We could use "is_plugin_active" because the "active_plugins" option is updated BEFORE the action is called.
         // However, this is not the case for the deactivation so for consistency we use the counterpart check.
         self::update_modules_state( function ( $check_plugin ) use ( $activated_plugin ) {
@@ -123,7 +123,7 @@ class QTX_Admin_Module_Manager {
      *
      * @param string $deactivated_plugin name of the plugin being deactivated.
      */
-    public static function register_plugin_deactivated( $deactivated_plugin ) {
+    public static function register_plugin_deactivated( string $deactivated_plugin ): void {
         // We can't use "is_plugin_active" because the "active_plugins" option is updated AFTER the action is called!
         // This is a problem of WP Core, but we pass a custom function as a workaround.
         self::update_modules_state( function ( $check_plugin ) use ( $deactivated_plugin ) {
@@ -131,7 +131,7 @@ class QTX_Admin_Module_Manager {
         } );
     }
 
-    public static function admin_notices() {
+    public static function admin_notices(): void {
         $options_modules = get_option( QTX_OPTIONS_MODULES_STATE, array() );
         if ( empty( $options_modules ) ) {
             $msg   = '<p>' . sprintf( __( 'Modules state undefined in %s. Please deactivate it and reactivate it again from the plugins page.', 'qtranslate' ), 'qTranslate&#8209;XT' ) . '</p>';

--- a/src/modules/admin_module_settings.php
+++ b/src/modules/admin_module_settings.php
@@ -31,7 +31,7 @@ class QTX_Admin_Module_Settings {
      * @param QTX_Admin_Module $module
      * @param integer $state
      */
-    public function __construct( $module, $state ) {
+    public function __construct( QTX_Admin_Module $module, int $state ) {
         $this->id     = $module->id;
         $this->name   = $module->name;
         $this->module = $module;
@@ -67,7 +67,7 @@ class QTX_Admin_Module_Settings {
      *
      * @return bool
      */
-    public function is_checked() {
+    public function is_checked(): bool {
         global $q_config;
 
         return ( isset( $q_config['admin_enabled_modules'][ $this->module->id ] ) && $q_config['admin_enabled_modules'][ $this->module->id ] ) || ( $this->state == QTX_MODULE_STATE_ACTIVE );
@@ -78,7 +78,7 @@ class QTX_Admin_Module_Settings {
      *
      * @return bool
      */
-    public function is_disabled() {
+    public function is_disabled(): bool {
         return ( QTX_Admin_Module_Manager::can_module_be_activated( $this->module ) != QTX_MODULE_STATE_ACTIVE );
     }
 
@@ -87,7 +87,7 @@ class QTX_Admin_Module_Settings {
      *
      * @return bool
      */
-    public function is_active() {
+    public function is_active(): bool {
         return $this->state == QTX_MODULE_STATE_ACTIVE;
     }
 
@@ -96,7 +96,7 @@ class QTX_Admin_Module_Settings {
      *
      * @return bool
      */
-    public function has_settings() {
+    public function has_settings(): bool {
         return $this->module->has_settings;
     }
 
@@ -106,7 +106,7 @@ class QTX_Admin_Module_Settings {
      *
      * @return QTX_Admin_Module_Settings[]
      */
-    public static function get_settings_modules() {
+    public static function get_settings_modules(): array {
         $states   = get_option( QTX_OPTIONS_MODULES_STATE, array() );
         $settings = array();
         foreach ( QTX_Admin_Module::get_modules() as $module ) {

--- a/src/modules/all-in-one-seo-pack/admin.php
+++ b/src/modules/all-in-one-seo-pack/admin.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 add_filter( 'qtranslate_admin_config', 'qtranxf_aioseop_add_admin_page_config' );
-function qtranxf_aioseop_add_admin_page_config( $page_configs ) {
+function qtranxf_aioseop_add_admin_page_config( array $page_configs ): array {
     // post.php
     $page_config          = array();
     $page_config['pages'] = array( 'post.php' => '', 'term.php' => '' );

--- a/src/modules/all-in-one-seo-pack/loader.php
+++ b/src/modules/all-in-one-seo-pack/loader.php
@@ -3,7 +3,7 @@
  * Built-in module for All in One SEO Pack
  */
 
-function qtranxf_aioseop_init_language( $url_info ) {
+function qtranxf_aioseop_init_language( array $url_info ): void {
     if ( $url_info['doing_front_end'] ) {
         require_once __DIR__ . '/front.php';
     } else {

--- a/src/modules/events-made-easy/admin.php
+++ b/src/modules/events-made-easy/admin.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 //}
 
 add_filter( 'qtranslate_admin_config', 'qtranxf_eme_add_admin_page_config' );
-function qtranxf_eme_add_admin_page_config( $page_configs ) {
+function qtranxf_eme_add_admin_page_config( array $page_configs ): array {
     {//admin.php?page=eme-manager
         $page_config = array();
 

--- a/src/modules/events-made-easy/loader.php
+++ b/src/modules/events-made-easy/loader.php
@@ -6,7 +6,7 @@
  * @author: johnclause, liedekef
  */
 
-function qtranxf_eme_init_language( $url_info ) {
+function qtranxf_eme_init_language( array $url_info ): void {
     if ( ! $url_info['doing_front_end'] ) {
         require_once __DIR__ . '/admin.php';
     }

--- a/src/modules/google-site-kit/loader.php
+++ b/src/modules/google-site-kit/loader.php
@@ -3,7 +3,7 @@
  * Built-in module for Google Site Kit
  */
 
-add_filter( 'googlesitekit_canonical_home_url', function ( $url ) {
+add_filter( 'googlesitekit_canonical_home_url', function ( string $url ): string {
     // bypass qtranxf_home_url and provide a fixed home URL to avoid disconnections
     return get_option( 'home' );
 } );

--- a/src/modules/gravity-forms/loader.php
+++ b/src/modules/gravity-forms/loader.php
@@ -18,7 +18,7 @@ class QTX_Module_Gravity_Forms {
         add_filter( "gform_pre_send_email", array( $this, "gform_pre_send_email" ) );
     }
 
-    public function gform_pre_render( $form ) {
+    public function gform_pre_render( array $form ): array {
         if ( ! $this->isEnabled() ) {
             return $form;
         }
@@ -92,13 +92,13 @@ class QTX_Module_Gravity_Forms {
         return $form;
     }
 
-    public function gform_form_action_attribute( $matches ) {
+    public function gform_form_action_attribute( array $matches ): string {
         global $q_config;
 
         return 'action="' . $this->convertURL( $matches[1], $q_config['language'] ) . '"';
     }
 
-    public function gform_form_tag( $tag ) {
+    public function gform_form_tag( string $tag ): string {
         if ( ! $this->isEnabled() ) {
             return $tag;
         }
@@ -107,7 +107,7 @@ class QTX_Module_Gravity_Forms {
         return $tag;
     }
 
-    public function gform_savecontinue_link( $save_button, $form ) {
+    public function gform_savecontinue_link( string $save_button, array $form ) {
         if ( ! $this->isEnabled() ) {
             return $save_button;
         }
@@ -116,7 +116,7 @@ class QTX_Module_Gravity_Forms {
         return $save_button;
     }
 
-    public function gform_confirmation( $confirmation, $form, $lead, $ajax ) {
+    public function gform_confirmation( $confirmation, $form, $lead, bool $ajax ) {
         if ( ! $this->isEnabled() ) {
             return $confirmation;
         }
@@ -125,7 +125,7 @@ class QTX_Module_Gravity_Forms {
         return $confirmation;
     }
 
-    public function gform_pre_send_email( $email ) {
+    public function gform_pre_send_email( array $email ): array {
         if ( ! $this->isEnabled() ) {
             return $email;
         }
@@ -135,7 +135,7 @@ class QTX_Module_Gravity_Forms {
         return $email;
     }
 
-    private function isEnabled() {
+    private function isEnabled(): bool {
         return ( function_exists( 'qtrans_useCurrentLanguageIfNotFoundUseDefaultLanguage' ) || function_exists( 'qtranxf_useCurrentLanguageIfNotFoundUseDefaultLanguage' ) );
     }
 
@@ -147,7 +147,7 @@ class QTX_Module_Gravity_Forms {
         }
     }
 
-    private function convertURL( $url, $lang ) {
+    private function convertURL( string $url, string $lang ): string {
         if ( function_exists( 'qtranxf_convertURL' ) ) {
             return qtranxf_convertURL( $url, $lang );
         } else {

--- a/src/modules/jetpack/loader.php
+++ b/src/modules/jetpack/loader.php
@@ -19,7 +19,7 @@ class QTX_Module_Jetpack {
      * @return array updated related posts
      * @see get_related_post_data_for_post in jetpack/modules/related_posts/jetpack-related-posts.php
      */
-    function translate_related_posts( $results ) {
+    function translate_related_posts( array $results ): array {
         return array_map( function ( $result ) {
             $result['title']   = qtranxf_useCurrentLanguageIfNotFoundShowAvailable( $result['title'] );
             $result['excerpt'] = qtranxf_useCurrentLanguageIfNotFoundShowAvailable( $result['excerpt'] );

--- a/src/modules/module_loader.php
+++ b/src/modules/module_loader.php
@@ -15,7 +15,7 @@ class QTX_Module_Loader {
      *
      * @bool true if module active.
      */
-    public static function is_module_active( $module_id ) {
+    public static function is_module_active( string $module_id ): bool {
         $modules_state = get_option( QTX_OPTIONS_MODULES_STATE, array() );
 
         return isset( $modules_state[ $module_id ] ) && $modules_state[ $module_id ] === QTX_MODULE_STATE_ACTIVE;
@@ -30,7 +30,7 @@ class QTX_Module_Loader {
      *
      * Note also the modules should be loaded before "qtranslate_init_language" is triggered.
      */
-    public static function load_active_modules() {
+    public static function load_active_modules(): void {
         $modules_state = get_option( QTX_OPTIONS_MODULES_STATE, array() );
 
         foreach ( $modules_state as $module_id => $state ) {

--- a/src/modules/slugs/admin.php
+++ b/src/modules/slugs/admin.php
@@ -26,7 +26,7 @@ register_uninstall_hook( QTRANSLATE_FILE, 'qtranxf_slugs_uninstall' );
 /**
  * Add support for taxonomies and optional integration with WooCommerce.
  */
-function qtranxf_slugs_taxonomies_hooks() {
+function qtranxf_slugs_taxonomies_hooks(): void {
     global $qtranslate_slugs;
 
     $taxonomies = $qtranslate_slugs->get_public_taxonomies();
@@ -49,7 +49,7 @@ function qtranxf_slugs_taxonomies_hooks() {
 /**
  * Do the installation, support multisite.
  */
-function qtranxf_slugs_multi_activate() {
+function qtranxf_slugs_multi_activate(): void {
     if ( is_plugin_active_for_network( plugin_basename( QTRANSLATE_FILE ) ) ) {
         $old_blog = get_current_blog_id();
         $blogs    = get_sites();
@@ -68,7 +68,7 @@ function qtranxf_slugs_multi_activate() {
 /**
  * Delete plugin stored data ( options and postmeta data ).
  */
-function qtranxf_slugs_uninstall() {
+function qtranxf_slugs_uninstall(): void {
     global $q_config, $wpdb;
 
     delete_option( QTX_OPTIONS_MODULE_SLUGS );
@@ -88,7 +88,7 @@ function qtranxf_slugs_uninstall() {
 /**
  * Activates and do the installation.
  */
-function qtranxf_slugs_activate() {
+function qtranxf_slugs_activate(): void {
     global $qtranslate_slugs;
 
     // regenerate rewrite rules in db
@@ -99,7 +99,7 @@ function qtranxf_slugs_activate() {
 /**
  * Actions when deactivating the plugin.
  */
-function qtranxf_slugs_deactivate() {
+function qtranxf_slugs_deactivate(): void {
     global $wp_rewrite;
     global $qtranslate_slugs;
 
@@ -111,7 +111,7 @@ function qtranxf_slugs_deactivate() {
 /**
  * Creates a metabox for every post type available.
  */
-function qtranxf_slugs_add_slug_meta_box() {
+function qtranxf_slugs_add_slug_meta_box(): void {
     global $wp_meta_boxes;
 
     //Replace slugs metabox only if existing and not already removed
@@ -126,7 +126,7 @@ function qtranxf_slugs_add_slug_meta_box() {
  *
  * @param $post (object) current post object
  */
-function qtranxf_slugs_draw_meta_box( $post ) {
+function qtranxf_slugs_draw_meta_box( $post ): void {
     global $q_config;
 
     // Use nonce for verification
@@ -155,7 +155,7 @@ function qtranxf_slugs_draw_meta_box( $post ) {
  *
  * @return string sanitized slug
  */
-function qtranxf_slugs_sanitize_post_slug( $slug, $post, $lang ) {
+function qtranxf_slugs_sanitize_post_slug( string $slug, WP_Post $post, string $lang ): string {
     $post_title = trim( qtranxf_use( $lang, $post->post_title ) );
     $post_name  = get_post_meta( $post->ID, QTX_SLUGS_META_PREFIX . $lang, true );
     if ( ! $post_name ) {
@@ -180,7 +180,7 @@ function qtranxf_slugs_sanitize_post_slug( $slug, $post, $lang ) {
  *
  * @return string the slug validated
  */
-function qtranxf_slugs_unique_post_slug( $slug, $post, $lang ) {
+function qtranxf_slugs_unique_post_slug( string $slug, WP_Post $post, string $lang ): string {
 
     $original_status = $post->post_status;
 
@@ -203,10 +203,11 @@ function qtranxf_slugs_unique_post_slug( $slug, $post, $lang ) {
  * @param string $post_status no uniqueness checks are made if the post is still draft or pending
  * @param string $post_type
  * @param integer $post_parent
+ * @param string $lang
  *
  * @return string unique slug for the post, based on language meta_value (with a -1, -2, etc. suffix)
  */
-function qtranxf_slugs_wp_unique_post_slug( $slug, $post_ID, $post_status, $post_type, $post_parent, $lang ) {
+function qtranxf_slugs_wp_unique_post_slug( string $slug, int $post_ID, string $post_status, string $post_type, int $post_parent, string $lang ): string {
     if ( in_array( $post_status, array( 'draft', 'pending', 'auto-draft' ) ) ) {
         return $slug;
     }
@@ -260,11 +261,11 @@ function qtranxf_slugs_wp_unique_post_slug( $slug, $post_ID, $post_status, $post
  * Saves the translated slug when the page is saved.
  *
  * @param int $post_id the post id
- * @param WP_Post $post the post object
+ * @param WP_Post|null $post the post object
  *
  * @return void
  */
-function qtranxf_slugs_save_postdata( $post_id, $post = null ) {
+function qtranxf_slugs_save_postdata( int $post_id, ?WP_Post $post = null ): void {
     global $q_config;
     if ( is_null( $post ) ) {
         $post = get_post( $post_id );
@@ -317,13 +318,13 @@ function qtranxf_slugs_sanitize_term_slug( $slug, $term, $lang ) {
  *
  * @param string $slug term slug to be made unique
  * @param WP_Term $term the term object the slug belongs to
- * @param object $lang language
+ * @param string $lang language
  *
  * @return string unique slug
  *
  * @since 1.0
  */
-function qtranxf_slugs_unique_term_slug( $slug, $term, $lang ) {
+function qtranxf_slugs_unique_term_slug( string $slug, WP_Term $term, string $lang ): string {
     global $wpdb;
 
     $query       = $wpdb->prepare( "SELECT term_id FROM $wpdb->termmeta WHERE meta_key = '%s' AND meta_value = '%s' AND term_id != %d ", QTX_SLUGS_META_PREFIX . $lang, $slug, $term->term_id );
@@ -362,7 +363,7 @@ function qtranxf_slugs_unique_term_slug( $slug, $term, $lang ) {
  *
  * @return void
  */
-function qtranxf_slugs_save_term( $term_id, $tt_id, $taxonomy ) {
+function qtranxf_slugs_save_term( int $term_id, int $tt_id, $taxonomy ): void {
     global $q_config;
     $cur_screen = get_current_screen();
     if ( ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE )
@@ -391,7 +392,7 @@ function qtranxf_slugs_save_term( $term_id, $tt_id, $taxonomy ) {
  *
  * @return void
  */
-function qtranxf_slugs_show_list_term_fields( $term ) {
+function qtranxf_slugs_show_list_term_fields( ?WP_Term $term ): void {
     global $q_config;
 
     $flag_location = qtranxf_flag_location(); ?>
@@ -413,7 +414,7 @@ function qtranxf_slugs_show_list_term_fields( $term ) {
  * Display multiple input fields, one per language for add term page.
  *
  */
-function qtranxf_slugs_show_add_term_fields() {
+function qtranxf_slugs_show_add_term_fields(): void {
     ?>
     <div class="form-field term-slug-wrap">
         <label><?php _e( 'Slugs per language', 'qtranslate' ) ?></label>
@@ -427,7 +428,7 @@ function qtranxf_slugs_show_add_term_fields() {
  *
  * @param WP_Term $term the term object
  */
-function qtranxf_slugs_show_edit_term_fields( $term ) {
+function qtranxf_slugs_show_edit_term_fields( WP_Term $term ): void {
     ?>
     <tr class="form-field term-slug-wrap">
         <th><?php _e( 'Slugs per language', 'qtranslate' ) ?></th>
@@ -440,7 +441,7 @@ function qtranxf_slugs_show_edit_term_fields( $term ) {
  * Display link to slugs settings for add custom tax admin page (e.g. WooCommerce product attributes).
  *
  */
-function qtranxf_slugs_show_add_taxonomy_slugs_option_link() {
+function qtranxf_slugs_show_add_taxonomy_slugs_option_link(): void {
     ?>
     <div class="form-field term-slug-wrap">
         <label><?php _e( 'Slugs per language', 'qtranslate' ) ?></label>
@@ -456,7 +457,7 @@ function qtranxf_slugs_show_add_taxonomy_slugs_option_link() {
  * Display link to slugs settings for edit custom tax admin page (e.g. WooCommerce product attributes).
  *
  */
-function qtranxf_slugs_show_edit_taxonomy_slugs_option_link() {
+function qtranxf_slugs_show_edit_taxonomy_slugs_option_link(): void {
     ?>
     <tr class="form-field term-slug-wrap">
         <th><?php _e( 'Slugs per language', 'qtranslate' ) ?></th>
@@ -473,7 +474,7 @@ function qtranxf_slugs_show_edit_taxonomy_slugs_option_link() {
 /**
  * Hide automatically the wordpress slug box in edit terms page.
  */
-function qtranxf_slugs_hide_term_slug_box() {
+function qtranxf_slugs_hide_term_slug_box(): void {
     global $pagenow;
     switch ( $pagenow ):
         case 'edit-tags.php':
@@ -522,21 +523,21 @@ function qtranxf_slugs_hide_term_slug_box() {
 /**
  * Hide quickedit slug.
  */
-function qtranxf_slugs_hide_quick_edit() {
+function qtranxf_slugs_hide_quick_edit(): void {
     echo "<!-- QTS remove quick edit box -->" . PHP_EOL;
     echo "<style media=\"screen\">" . PHP_EOL;
     echo "  .inline-edit-row fieldset.inline-edit-col-left .inline-edit-col *:first-child + label { display: none !important }" . PHP_EOL;
     echo "</style>" . PHP_EOL;
 }
 
-function qtranxf_slugs_taxonomy_columns( $columns ) {
+function qtranxf_slugs_taxonomy_columns( array $columns ): array {
     unset( $columns['slug'] );
     $columns['qts-slug'] = __( 'Slug' );
 
     return $columns;
 }
 
-function qtranxf_slugs_taxonomy_custom_column( $str, $column_name, $term_id ) {
+function qtranxf_slugs_taxonomy_custom_column( $str, string $column_name, int $term_id ): bool {
     global $q_config;
 
     if ( $column_name === 'qts-slug' ) {
@@ -557,9 +558,9 @@ function qtranxf_slugs_taxonomy_custom_column( $str, $column_name, $term_id ) {
  * @param (array) $terms
  * @param (int|array) $obj_id
  * @param (string|array) $taxonomy
- * @param (array) $taxonomy
+ * @param (array) $args
  */
-function qtranxf_slugs_get_object_terms( $terms, $obj_id, $taxonomy, $args ) {
+function qtranxf_slugs_get_object_terms( array $terms, $obj_id, $taxonomy, array $args ): array {
 
     global $pagenow;
     global $q_config;
@@ -596,7 +597,7 @@ function qtranxf_slugs_get_object_terms( $terms, $obj_id, $taxonomy, $args ) {
  * @param (array) $terms
  * @param (string|array) $taxonomy
  */
-function qtranxf_slugs_get_terms( $terms, $taxonomy ) {
+function qtranxf_slugs_get_terms( array $terms, $taxonomy ): array {
 
     global $pagenow;
     global $q_config;
@@ -622,7 +623,7 @@ function qtranxf_slugs_get_terms( $terms, $taxonomy ) {
     return $terms;
 }
 
-function qtranxf_slugs_ma_module_updated() {
+function qtranxf_slugs_ma_module_updated(): void {
     if ( QTX_Module_Loader::is_module_active( 'slugs' ) ) {
         qtranxf_slugs_multi_activate();
     } else {

--- a/src/modules/slugs/admin_migrate_qts.php
+++ b/src/modules/slugs/admin_migrate_qts.php
@@ -11,7 +11,7 @@ const QTX_SLUGS_LEGACY_QTS_OPTIONS_NAME   = 'qts_options';
  *
  * @return string messages giving details, empty if new meta found or no legacy meta found.
  */
-function qtranxf_slugs_check_migrate_qts() {
+function qtranxf_slugs_check_migrate_qts(): string {
     global $wpdb;
 
     /**
@@ -46,7 +46,7 @@ function qtranxf_slugs_check_migrate_qts() {
  *
  * @return string messages giving details.
  */
-function qtranxf_slugs_migrate_qts_meta( $db_commit ) {
+function qtranxf_slugs_migrate_qts_meta( bool $db_commit ): string {
     global $wpdb;
 
     $new_prefix = QTX_SLUGS_META_PREFIX;
@@ -57,11 +57,12 @@ function qtranxf_slugs_migrate_qts_meta( $db_commit ) {
      *
      * @param string $table name of the meta table (postmeta, termmeta)
      * @param string $colid column name of the parent id (post_id, term_id)
+     * @param bool $db_commit true to commit changes, false for dry-run mode.
      * @param string[] $msg array of messages, updated
      *
      * @return void
      */
-    $migrate_meta = function ( $table, $colid, $db_commit, &$msg ) use ( $wpdb, $old_prefix, $new_prefix ) {
+    $migrate_meta = function ( string $table, string $colid, bool $db_commit, array &$msg ) use ( $wpdb, $old_prefix, $new_prefix ): void {
         // Escape '_' against LIKE wildcards.
         $old_esc = str_replace( '_', '\_', $old_prefix );
         $new_esc = str_replace( '_', '\_', $new_prefix );
@@ -103,7 +104,7 @@ function qtranxf_slugs_migrate_qts_meta( $db_commit ) {
  *
  * @return string messages giving details.
  */
-function qtranxf_slugs_migrate_qts_options( $db_commit ) {
+function qtranxf_slugs_migrate_qts_options( bool $db_commit ): string {
     $msg = [];
 
     $qts_options = get_option( QTX_SLUGS_LEGACY_QTS_OPTIONS_NAME );
@@ -148,7 +149,7 @@ function qtranxf_slugs_migrate_qts_options( $db_commit ) {
  *
  * @return string messages giving details.
  */
-function qtranxf_slugs_migrate_qts_data( $db_commit ) {
+function qtranxf_slugs_migrate_qts_data( bool $db_commit ): string {
     $msg   = [];
     $msg[] = $db_commit ? __( 'Migrate slugs:', 'qtranslate' ) : __( "Dry-run mode:", 'qtranslate' );
     $msg[] = qtranxf_slugs_migrate_qts_meta( $db_commit );

--- a/src/modules/slugs/admin_settings.php
+++ b/src/modules/slugs/admin_settings.php
@@ -8,7 +8,7 @@ add_action( 'qtranslate_configuration', 'qtranxf_slugs_show_settings_page' );
  *
  * @return array
  */
-function qtranxf_slugs_get_settings() {
+function qtranxf_slugs_get_settings(): array {
     $output                      = array();
     $output['qts_page_sections'] = qtranxf_slugs_options_page_sections();
     $output['qts_page_fields']   = qtranxf_slugs_options_page_fields();
@@ -21,7 +21,7 @@ function qtranxf_slugs_get_settings() {
  *
  * @return void echoes output
  */
-function qtranxf_slugs_section_fn( $section_id = '' ) {
+function qtranxf_slugs_section_fn( string $section_id = '' ): void {
     switch ( $section_id ) {
         case 'post_types':
             echo "<p>" . __( 'For example, the post_type <kbd>books</kbd>, in Spanish would be displayed as <code>https://example.org/es/libros/post-type-name/</code>. If you leave this blank will use the default option when you <a href="https://developer.wordpress.org/reference/functions/register_post_type/">registered</a> the post_type.', 'qtranslate' ) . "</p>";
@@ -38,7 +38,7 @@ function qtranxf_slugs_section_fn( $section_id = '' ) {
  *
  * @return void echoes output
  */
-function qtranxf_slugs_show_form_field( $args = array() ) {
+function qtranxf_slugs_show_form_field( array $args = array() ): void {
     global $qtranslate_slugs;
     global $q_config;
 
@@ -189,7 +189,7 @@ function qtranxf_slugs_show_form_field( $args = array() ) {
  *
  * @return void echoes output
  */
-function qtranxf_slugs_show_settings_page() {
+function qtranxf_slugs_show_settings_page(): void {
     $settings_output = qtranxf_slugs_get_settings();
 
     if ( empty( $settings_output['qts_page_sections'] ) ) {
@@ -217,7 +217,7 @@ function qtranxf_slugs_show_settings_page() {
  *
  * @return array
  */
-function qtranxf_slugs_validate_options( $input ) {
+function qtranxf_slugs_validate_options( array $input ): array {
     global $q_config;
     // Initialize lookup array to be used to make sure slug for a specific language is unique
     $slugs_lookup_array = array();
@@ -352,7 +352,7 @@ function qtranxf_slugs_validate_options( $input ) {
     return $valid_input;
 }
 
-function qtranxf_slugs_update_settings() {
+function qtranxf_slugs_update_settings(): void {
     global $qtranslate_slugs;
 
     $qts_settings = isset( $_POST[ QTX_OPTIONS_MODULE_SLUGS ] ) ? qtranxf_slugs_validate_options( $_POST[ QTX_OPTIONS_MODULE_SLUGS ] ) : array();
@@ -372,7 +372,7 @@ function qtranxf_slugs_update_settings() {
  *
  * @return array key=$id, array value=$title in: add_settings_section( $id, $title, $callback, $page );
  */
-function qtranxf_slugs_options_page_sections() {
+function qtranxf_slugs_options_page_sections(): array {
     $sections               = array();
     $sections['post_types'] = __( 'Post types', 'qtranslate' );
     $sections['taxonomies'] = __( 'Taxonomies', 'qtranslate' );
@@ -385,7 +385,7 @@ function qtranxf_slugs_options_page_sections() {
  *
  * @return array
  */
-function qtranxf_slugs_get_multi_txt_choices() {
+function qtranxf_slugs_get_multi_txt_choices(): array {
     global $q_config;
 
     $choices = array();
@@ -402,7 +402,7 @@ function qtranxf_slugs_get_multi_txt_choices() {
  *
  * @return array
  */
-function qtranxf_slugs_options_page_fields() {
+function qtranxf_slugs_options_page_fields(): array {
     global $qtranslate_slugs;
     $options = array();
 
@@ -419,7 +419,7 @@ function qtranxf_slugs_options_page_fields() {
     return array_filter( $options );
 }
 
-function qtranxf_slugs_options_page_build_slug_fields( $object, $target_section, $id_prefix ) {
+function qtranxf_slugs_options_page_build_slug_fields( $object, string $target_section, string $id_prefix ): array {
     if ( is_array( $object->rewrite ) && array_key_exists( 'slug', $object->rewrite ) ) {
         $slug = ltrim( $object->rewrite['slug'], "/" );
     } else {

--- a/src/modules/slugs/slugs.php
+++ b/src/modules/slugs/slugs.php
@@ -498,13 +498,13 @@ class QTX_Module_Slugs {
     /**
      * Parse a hierarquical name and extract the last one
      *
-     * @param string $lang Page path
+     * @param string|bool $lang Page path
      *
      * @return string
      *
      * @since 1.0
      */
-    public function get_current_url( $lang = false ) {
+    public function get_current_url( $lang = false ): string {
 
         if ( ! $lang ) {
             $lang = $this->get_temp_lang();
@@ -520,13 +520,14 @@ class QTX_Module_Slugs {
     /**
      * Retrieve the home url for a given site.
      *
-     * @param int $blog_id (optional) Blog ID. Defaults to current blog.
-     * @param string $path (optional) Path relative to the home url.
-     * @param string $scheme (optional) Scheme to give the home url context. Currently 'http', 'https'.
+     * @param string $url The complete home URL including scheme and path.
+     * @param string $path Path relative to the home url.
+     * @param string|null $scheme (optional) Scheme to give the home url context. Currently 'http', 'https'.
+     * @param int|null $blog_id (optional) Site ID, or null for the current site.
      *
      * @return string Home url link with optional path appended.
      */
-    public function home_url( $url, $path, $scheme, $blog_id ) {
+    public function home_url( string $url, string $path, ?string $scheme, ?int $blog_id ): string {
         if ( ! in_array( $scheme, array( 'http', 'https' ) ) ) {
             $scheme = is_ssl() && ! is_admin() ? 'https' : 'http';
         }
@@ -562,7 +563,7 @@ class QTX_Module_Slugs {
      *
      * @return string processed permastruct
      */
-    public function get_extra_permastruct( $permastruct = false, $name = false ) {
+    public function get_extra_permastruct( $permastruct = false, $name = false ): string {
 
         if ( ! $name || ! $permastruct ) {
             return '';
@@ -641,9 +642,9 @@ class QTX_Module_Slugs {
      * @param WP_Post $post the post data
      * @param bool $leavename parameter used by get_permalink. Whether to keep post name or page name.
      *
-     * @return string the link translated
+     * @return string|false the link translated
      */
-    public function post_link( $link, $post, $leavename ) {
+    public function post_link( string $link, WP_Post $post, bool $leavename ) {
         global $q_config; //TODO: q_config  : url_mode
 
         $rewritecode = array(
@@ -744,7 +745,7 @@ class QTX_Module_Slugs {
      *
      * @return string the link translated
      */
-    public function _get_page_link( $link, $id ) {
+    public function _get_page_link( string $link, int $id ): string {
         global $post, $wp_rewrite, $q_config;  //TODO: q_config  : url_mode
 
         $current_post = $post;
@@ -785,10 +786,10 @@ class QTX_Module_Slugs {
      * @param WP_Term $term
      * @param object $taxonomy
      *
-     * @return string the link translated
+     * @return string|WP_Error the link translated
      */
     //TODO: review this function vs get_term_link(), e.g. checks and error handling may be unneeded here
-    public function term_link( $link, $term, $taxonomy ) {
+    public function term_link( string $link, WP_Term $term, $taxonomy ) {
         global $wp_rewrite;
 
         // parse normal term names for ?tag=tagname
@@ -875,7 +876,7 @@ class QTX_Module_Slugs {
      *
      * @return array of public taxonomies objects
      */
-    public function get_public_taxonomies() {
+    public function get_public_taxonomies(): array {
         $all_taxonomies = get_taxonomies( array( 'public' => true, 'show_ui' => true ), 'objects' );
         $taxonomies     = array();
 
@@ -893,7 +894,7 @@ class QTX_Module_Slugs {
      *
      * @return array of public post_types objects
      */
-    public function get_public_post_types() {
+    public function get_public_post_types(): array {
         $all_post_types = get_post_types( array( 'public' => true ), 'objects' );
         $post_types     = array();
 
@@ -918,7 +919,7 @@ class QTX_Module_Slugs {
     /**
      * Helper: news rules to translate the URL bases.
      *
-     * @param string $name name of extra permastruct
+     * @param string|false $name name of extra permastruct
      */
     private function generate_extra_rules( $name = false ) {
         global $q_config;
@@ -948,7 +949,7 @@ class QTX_Module_Slugs {
      *
      * @return string
      */
-    private function get_last_slash( $slug ) {
+    private function get_last_slash( string $slug ): string {
         $slug          = rawurlencode( urldecode( $slug ) );
         $slug          = str_replace( '%2F', '/', $slug );
         $slug          = str_replace( '%20', ' ', $slug );
@@ -965,7 +966,7 @@ class QTX_Module_Slugs {
      *
      * @return mixed Null when complete.
      */
-    private function get_page_id_by_path( $page_path, $post_type = 'page' ) {
+    private function get_page_id_by_path( string $page_path, string $post_type = 'page' ) {
         global $wpdb;
 
         // Handle cases where custom query vars with the same names of specific internal query vars (e.g. 'name') are structured as arrays for any reason.
@@ -1034,7 +1035,7 @@ class QTX_Module_Slugs {
      *
      * @return array|WP_Post|null Null when complete.
      */
-    private function get_page_by_path( $page_path, $post_type = 'page' ) {
+    private function get_page_by_path( string $page_path, string $post_type = 'page' ) {
         $foundid = $this->get_page_id_by_path( $page_path, $post_type );
         if ( $foundid ) {
             return get_post( $foundid );
@@ -1048,7 +1049,7 @@ class QTX_Module_Slugs {
      *
      * @return boolean
      */
-    private function ignore_rewrite_caller() {
+    private function ignore_rewrite_caller(): bool {
         $backtrace = debug_backtrace();
 
         $ignore_functions = array(
@@ -1087,7 +1088,7 @@ class QTX_Module_Slugs {
      * @return string
      */
     //TODO: $link seems to be unused (always false), to be removed and function cleaned up
-    private function get_category_parents( $id, $link = false, $separator = '/', $nicename = false, $visited = array() ) {
+    private function get_category_parents( int $id, bool $link = false, string $separator = '/', bool $nicename = false, array $visited = array() ): string {
         $chain  = '';
         $parent = get_category( $id );
 
@@ -1127,7 +1128,7 @@ class QTX_Module_Slugs {
      *
      * @return string Page URI.
      */
-    private function get_page_uri( $page ) {
+    private function get_page_uri( $page ): string {
         if ( ! is_object( $page ) ) {
             $page = get_post( $page );
         }
@@ -1166,7 +1167,7 @@ class QTX_Module_Slugs {
      * @return array|false|object|WP_Error|WP_Term|null Term Row from database. Will return false if $taxonomy does not exist or $term was not found.
      * TODO: simplify return type and error handling, unexpected results may cause bugs!
      */
-    private function get_term_by( $field, $value, $taxonomy ) {
+    private function get_term_by( string $field, $value, string $taxonomy ) {
         global $wpdb;
 
         if ( ! taxonomy_exists( $taxonomy ) ) {

--- a/src/modules/slugs/utils.php
+++ b/src/modules/slugs/utils.php
@@ -3,14 +3,15 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-//TOTO: check if this function needs to be retained as documented or not
+// TODO: check if this function needs to be retained as documented or not
+// TODO: clarify lang type bool|string
 function qtranxf_slugs_get_url( $lang = false ) {
     global $qtranslate_slugs;
 
     return $qtranslate_slugs->get_current_url( $lang );
 }
 
-function qtranxf_slugs_convert_url( $url, $lang ) {
+function qtranxf_slugs_convert_url( string $url, $lang ): string {
     if ( empty( $url ) ) {
         return qtranxf_slugs_get_url( $lang );
     }

--- a/src/modules/woo-commerce/admin.php
+++ b/src/modules/woo-commerce/admin.php
@@ -3,7 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-function qtranxf_wc_add_filters_admin() {
+function qtranxf_wc_add_filters_admin(): void {
     // priority 20 is used because in case other plugins add some untranslated content on normal priority
     // it will still hopefully then get translated.
     $admin_hooks = array(
@@ -46,12 +46,12 @@ function qtranxf_wc_add_filters_admin() {
 qtranxf_wc_add_filters_admin();
 
 add_action( 'admin_enqueue_scripts', 'qtranxf_wc_add_admin_styles' );
-function qtranxf_wc_add_admin_styles() {
+function qtranxf_wc_add_admin_styles(): void {
     wp_enqueue_style( 'qtranxf_wc_qtranslate_admin', plugins_url( '/css/modules/woo-commerce.css', QTRANSLATE_FILE ), array(), QTX_VERSION );
 }
 
 add_filter( 'qtranslate_admin_config', 'qtranxf_wc_add_admin_page_config' );
-function qtranxf_wc_add_admin_page_config( $page_configs ) {
+function qtranxf_wc_add_admin_page_config( array $page_configs ): array {
     // post.php
     // TODO refactor append config
     if ( ! isset( $page_configs['post'] ) ) {
@@ -241,7 +241,7 @@ function qtranxf_wc_add_admin_page_config( $page_configs ) {
     return $page_configs;
 }
 
-function qtranxf_wc_email_get_option( $value_translated, $wce /* WC_Email object*/, $value = null, $key = null, $empty_value = null ) {
+function qtranxf_wc_email_get_option( $value_translated, WC_Email $wce, $value = null, $key = null, $empty_value = null ) {
     if ( ! $value ) {
         return $value_translated; // so that older WC versions do not get nasty output
     }
@@ -257,11 +257,11 @@ add_filter( 'woocommerce_variation_option_name', 'qtranxf_term_name_encoded', 5 
  * Append the language to the link for changing the order status, so that mails are sent in the language the customer
  * used during the order process
  *
- * @param $url
+ * @param string $url
  *
  * @return string
  */
-function qtranxf_wc_admin_url_append_language( $url ) {
+function qtranxf_wc_admin_url_append_language( string $url ): string {
     if ( strpos( $url, 'action=woocommerce_mark_order_status' ) ) {
         $components = parse_url( $url );
         $params     = array();
@@ -285,11 +285,11 @@ add_filter( 'admin_url', 'qtranxf_wc_admin_url_append_language' );
  * Append the language to ajax links on the order edit page, so that mails are sent in the language the customer used
  * during the order process
  *
- * @param $url
+ * @param string $url
  *
  * @return string
  */
-function qtranxf_wc_admin_url_append_language_edit_page( $url ) {
+function qtranxf_wc_admin_url_append_language_edit_page( string $url ): string {
     if ( strpos( $url, 'admin-ajax.php' ) === false || ! isset( $_GET['action'] ) || ! isset( $_GET['post'] ) || $_GET['action'] != 'edit' ) {
         return $url;
     }
@@ -342,7 +342,7 @@ add_filter( 'option_woocommerce_email_from_name', 'qtranxf_wc_admin_email_option
  * This helps to use order's language on re-sent emails from post.php order edit page.
  *
  * @param $content
- * @param WC_Order $order
+ * @param WC_Order|null $order
  *
  * @return array|mixed|string|void
  */
@@ -368,7 +368,7 @@ add_filter( 'woocommerce_email_order_items_table', 'qtranxf_wc_admin_email_trans
  *
  * @param WC_Order $order
  */
-function qtranxf_wc_admin_before_resend_order_emails( $order ) {
+function qtranxf_wc_admin_before_resend_order_emails( $order ): void {
     if ( ! ( $order && $order->get_id() ) ) {
         return;
     }
@@ -387,14 +387,14 @@ add_action( 'woocommerce_before_resend_order_emails', 'qtranxf_wc_admin_before_r
 /**
  * Undo the effect of qtranxf_wc_admin_before_resend_order_emails
  */
-function qtranxf_wc_admin_after_resend_order_emails( $order ) {
+function qtranxf_wc_admin_after_resend_order_emails( $order ): void {
     global $q_config;
     $q_config['language'] = $q_config['url_info']['language'];
 }
 
 add_action( 'woocommerce_after_resend_order_email', 'qtranxf_wc_admin_after_resend_order_emails' );
 
-function qtranxf_wc_admin_filters() {
+function qtranxf_wc_admin_filters(): void {
     global $pagenow;
     switch ( $pagenow ) {
         case 'admin.php':

--- a/src/modules/woo-commerce/front.php
+++ b/src/modules/woo-commerce/front.php
@@ -3,7 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-function qtranxf_wc_add_filters_front() {
+function qtranxf_wc_add_filters_front(): void {
 
     remove_filter( 'get_post_metadata', 'qtranxf_filter_postmeta', 5 );
     add_filter( 'get_post_metadata', 'qtranxf_wc_filter_postmeta', 5, 4 );
@@ -41,7 +41,7 @@ function qtranxf_wc_add_filters_front() {
     add_filter( 'woocommerce_paypal_args', 'qtranxf_wc_paypal_args' );
 }
 
-function qtranxf_wc_filter_postmeta( $original_value, $object_id, $meta_key = '', $single = false ) {
+function qtranxf_wc_filter_postmeta( $original_value, int $object_id, string $meta_key = '', bool $single = false ) {
     switch ( $meta_key ) {
         case '_product_attributes':
             return $original_value;
@@ -66,7 +66,7 @@ function qtranxf_wc_filter_postmeta( $original_value, $object_id, $meta_key = ''
  * @see wc_dropdown_variation_attribute_options (single-product/add-to-cart/variable.php)
  *
  */
-function qtranxf_wc_dropdown_variation_attribute_options_args( $args ) {
+function qtranxf_wc_dropdown_variation_attribute_options_args( array $args ): array {
     if ( isset( $args['options'] ) ) {
         $args['options'] = qtranxf_useCurrentLanguageIfNotFoundUseDefaultLanguage( $args['options'] );
     }
@@ -86,7 +86,7 @@ function qtranxf_wc_save_post_meta( $order_id ) {
     add_post_meta( $order_id, '_user_language', $q_config['language'], true );
 }
 
-function qtranxf_wc_paypal_args( $args ) {
+function qtranxf_wc_paypal_args( array $args ): array {
     $args['lc'] = get_locale();
 
     return $args;
@@ -104,7 +104,7 @@ if ( ! wp_doing_cron() ) {
  *
  * @return string cart hash with language information
  */
-function qtranxf_wc_get_cart_hash( $cart ) {
+function qtranxf_wc_get_cart_hash( array $cart ): string {
     $lang = qtranxf_getLanguage();
 
     return md5( json_encode( $cart ) . $lang );
@@ -116,7 +116,7 @@ function qtranxf_wc_get_cart_hash( $cart ) {
  *
  * @param array $cart wc variable holding contents of the cart without language information.
  */
-function qtranxf_wc_set_cookies_cart_hash( $cart ) {
+function qtranxf_wc_set_cookies_cart_hash( array $cart ): void {
     $hash = qtranxf_wc_get_cart_hash( $cart );
     wc_setcookie( 'woocommerce_cart_hash', $hash );
 }
@@ -127,7 +127,7 @@ function qtranxf_wc_set_cookies_cart_hash( $cart ) {
  *
  * @param WC_Cart $wc_cart wc object without language information.
  */
-function qtranxf_wc_cart_loaded_from_session( $wc_cart ) {
+function qtranxf_wc_cart_loaded_from_session( WC_Cart $wc_cart ): void {
     if ( headers_sent() ) {
         return;
     }
@@ -143,7 +143,7 @@ add_action( 'woocommerce_cart_loaded_from_session', 'qtranxf_wc_cart_loaded_from
  *
  * @param bool $set is true if cookies need to be set, otherwse they are unset in calling function.
  */
-function qtranxf_wc_set_cart_cookies( $set ) {
+function qtranxf_wc_set_cart_cookies( bool $set ): void {
     if ( $set ) {
         $wc      = WC();
         $wc_cart = $wc->cart;
@@ -163,7 +163,7 @@ add_action( 'woocommerce_set_cart_cookies', 'qtranxf_wc_set_cart_cookies' );
  *
  * @return string cart hash with language information
  */
-function qtranxf_wc_cart_hash( $hash, $cart ) {
+function qtranxf_wc_cart_hash( string $hash, array $cart ): string {
     $new_hash = qtranxf_wc_get_cart_hash( $cart );
     if ( ! headers_sent() ) {
         wc_setcookie( 'woocommerce_cart_hash', $new_hash );

--- a/src/modules/woo-commerce/loader.php
+++ b/src/modules/woo-commerce/loader.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-function qtranxf_wc_init_language( $url_info ) {
+function qtranxf_wc_init_language( array $url_info ): void {
     if ( $url_info['doing_front_end'] ) {
         require_once __DIR__ . '/front.php';
     } else {
@@ -27,7 +27,7 @@ add_action( 'qtranslate_init_language', 'qtranxf_wc_init_language' );
  *
  * @return array possibly modified $url_info.
  */
-function qtranxf_wc_detect_language( $url_info ) {
+function qtranxf_wc_detect_language( array $url_info ): array {
     if ( isset( $url_info['cookie_lang_front'] ) && $url_info['cookie_lang_front'] != $url_info['language'] ) {
         // language is about to switch
         if ( ! empty( $_GET['wc-ajax'] ) && ! empty( $url_info['doing_front_end'] ) ) {
@@ -49,7 +49,7 @@ add_filter( 'qtranslate_detect_language', 'qtranxf_wc_detect_language', 5 );
  * For some cases (e.g. variations updates) the webhook is generated through AJAX instead of cron.
  * In that context, qwc-admin.php is loaded instead of qwc-front.php
  */
-function qtranxf_wc_deliver_webhook_async( $webhook_id, $arg ) {
+function qtranxf_wc_deliver_webhook_async( $webhook_id, $arg ): void {
     if ( function_exists( 'qtranxf_get_front_page_config' ) ) {
         $page_configs = qtranxf_get_front_page_config();
         if ( ! empty( $page_configs['']['filters'] ) ) {

--- a/src/modules/wp-seo/loader.php
+++ b/src/modules/wp-seo/loader.php
@@ -5,7 +5,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-function qtranxf_wpseo_init_language( $url_info ) {
+function qtranxf_wpseo_init_language( array $url_info ): void {
     if ( $url_info['doing_front_end'] ) {
         require_once __DIR__ . '/wp-seo-front.php';
     } else {

--- a/src/modules/wp-seo/wp-seo-admin.php
+++ b/src/modules/wp-seo/wp-seo-admin.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 add_filter( 'qtranslate_admin_config', 'qtranxf_wpseo_load_admin_page_config' );
-function qtranxf_wpseo_load_admin_page_config( $page_configs ) {
+function qtranxf_wpseo_load_admin_page_config( array $page_configs ): array {
     assert( ! isset( $page_configs['yoast_wpseo'] ) );
 
     $page_configs['yoast_wpseo'] = array(

--- a/src/modules/wp-seo/wp-seo-front.php
+++ b/src/modules/wp-seo/wp-seo-front.php
@@ -3,7 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-function qtranxf_wpseo_add_filters_front() {
+function qtranxf_wpseo_add_filters_front(): void {
     // Use indexation on "publish/update" events to save all languages data in indexable tables.
     // If indexation is allowed on the frontend then indexable table saves data of the first visited page
     // and other languages are missed.
@@ -31,7 +31,7 @@ function qtranxf_wpseo_add_filters_front() {
         add_filter( $name, 'qtranxf_useCurrentLanguageIfNotFoundUseDefaultLanguage', $priority );
     }
 
-    function qtranxf_wpseo_webpage_schema( $piece, $context ) {
+    function qtranxf_wpseo_webpage_schema( array $piece, string $context ): array {
         if ( isset( $piece['description'] ) ) {
             $piece['description'] = qtranxf_useCurrentLanguageIfNotFoundUseDefaultLanguage( $piece['description'] );
         }
@@ -44,7 +44,7 @@ function qtranxf_wpseo_add_filters_front() {
 
     add_filter( 'wpseo_schema_webpage', 'qtranxf_wpseo_webpage_schema', 10, 2 );
 
-    function qtranxf_wpseo_breadcrumbs_link( $link_info, $index, $crumbs ) {
+    function qtranxf_wpseo_breadcrumbs_link( array $link_info, int $index, array $crumbs ): array {
         global $q_config;
 
         if ( isset( $link_info['text'] ) ) {
@@ -59,7 +59,7 @@ function qtranxf_wpseo_add_filters_front() {
 
     add_filter( 'wpseo_breadcrumb_single_link_info', 'qtranxf_wpseo_breadcrumbs_link', 10, 3 );
 
-    function qtranxf_wpseo_schema_organization( $data ) {
+    function qtranxf_wpseo_schema_organization( array $data ): array {
         global $q_config;
 
         if ( isset( $data['@id'] ) ) {
@@ -86,7 +86,7 @@ function qtranxf_wpseo_add_filters_front() {
 
     add_filter( 'wpseo_schema_organization', 'qtranxf_wpseo_schema_organization' );
 
-    function qtranxf_wpseo_schema_website( $data ) {
+    function qtranxf_wpseo_schema_website( array $data ): array {
         global $q_config;
 
         if ( isset( $data['@id'] ) ) {
@@ -104,7 +104,7 @@ function qtranxf_wpseo_add_filters_front() {
 
     add_filter( 'wpseo_schema_website', 'qtranxf_wpseo_schema_website' );
 
-    function qtranxf_wpseo_json_ld_search_url( $search_url ) {
+    function qtranxf_wpseo_json_ld_search_url( string $search_url ): string {
         global $q_config;
 
         return qtranxf_convertURL( $search_url, $q_config['language'] );
@@ -112,7 +112,7 @@ function qtranxf_wpseo_add_filters_front() {
 
     add_filter( 'wpseo_json_ld_search_url', 'qtranxf_wpseo_json_ld_search_url', 10, 3 );
 
-    function qtranxf_wpseo_schema_imageobject( $data ) {
+    function qtranxf_wpseo_schema_imageobject( array $data ): array {
         global $q_config;
 
         if ( isset( $data['@id'] ) ) {
@@ -124,7 +124,7 @@ function qtranxf_wpseo_add_filters_front() {
 
     add_filter( 'wpseo_schema_imageobject', 'qtranxf_wpseo_schema_imageobject' );
 
-    function qtranxf_wpseo_schema_webpage( $data ) {
+    function qtranxf_wpseo_schema_webpage( array $data ): array {
         global $q_config;
 
         $lang = $q_config['language'];
@@ -154,7 +154,7 @@ function qtranxf_wpseo_add_filters_front() {
 
     add_filter( 'wpseo_schema_webpage', 'qtranxf_wpseo_schema_webpage' );
 
-    function qtranxf_wpseo_schema_breadcrumb( $data ) {
+    function qtranxf_wpseo_schema_breadcrumb( array $data ): array {
         global $q_config;
 
         if ( isset( $data['@id'] ) ) {
@@ -166,7 +166,7 @@ function qtranxf_wpseo_add_filters_front() {
 
     add_filter( 'wpseo_schema_breadcrumb', 'qtranxf_wpseo_schema_breadcrumb' );
 
-    function qtranxf_wpseo_schema_person( $data ) {
+    function qtranxf_wpseo_schema_person( array $data ): array {
         global $q_config;
 
         //$data['@id'] = qtranxf_convertURL($data['@id'], $lang); //Not sure is it required to filter or not???
@@ -179,7 +179,7 @@ function qtranxf_wpseo_add_filters_front() {
 
     add_filter( 'wpseo_schema_person', 'qtranxf_wpseo_schema_person' );
 
-    function qtranxf_wpseo_next_prev_filter( $link ) {
+    function qtranxf_wpseo_next_prev_filter( string $link ): string {
         global $q_config;
 
         if ( preg_match_all( '/<link[^>]+href=([\'"])(?<href>.+?)\1[^>]*>/i', $link, $link_extract_href ) &&

--- a/src/options.php
+++ b/src/options.php
@@ -105,7 +105,7 @@ global $qtranslate_options;
  * other plugins and themes should not use global variables directly, they are subject to change at any time.
  * @since 3.3
  */
-function qtranxf_set_default_options( &$ops ) {
+function qtranxf_set_default_options( ?array &$ops ): void {
     $ops = array();
 
     // options processed in a standardized way
@@ -175,13 +175,13 @@ function qtranxf_set_default_options( &$ops ) {
 }
 
 
-function qtranxf_language_predefined( $lang ) {
+function qtranxf_language_predefined( string $lang ): bool {
     $language_names = qtranxf_default_language_name();
 
     return isset( $language_names[ $lang ] );
 }
 
-function qtranxf_language_configured( $prop, $opn = null ) {
+function qtranxf_language_configured( string $prop, ?string $opn = null ) {
     global $qtranslate_options;
     $val = call_user_func( 'qtranxf_default_' . $prop );
     if ( ! $opn ) {
@@ -203,7 +203,7 @@ function qtranxf_language_configured( $prop, $opn = null ) {
  * Fill merged array of stored and pre-defined language properties
  * @since 3.3
  */
-function qtranxf_languages_configured( &$cfg ) {
+function qtranxf_languages_configured( array &$cfg ): array {
     global $qtranslate_options;
     foreach ( $qtranslate_options['languages'] as $name => $option ) {
         $cfg[ $name ] = qtranxf_language_configured( $name, $option );
@@ -216,7 +216,7 @@ function qtranxf_languages_configured( &$cfg ) {
  * Load enabled languages properties from  database
  * @since 3.3
  */
-function qtranxf_load_languages_enabled() {
+function qtranxf_load_languages_enabled(): void {
     global $q_config, $qtranslate_options;
     foreach ( $qtranslate_options['languages'] as $name => $option ) {
         $func = 'qtranxf_default_' . $name;
@@ -237,7 +237,7 @@ function qtranxf_load_languages_enabled() {
     }
 }
 
-function qtranxf_load_option( $name, $default_value = null ) {
+function qtranxf_load_option( string $name, $default_value = null ): void {
     global $q_config, $qtranslate_options;
     $val = get_option( 'qtranslate_' . $name );
     if ( $val === false ) {
@@ -256,7 +256,7 @@ function qtranxf_load_option( $name, $default_value = null ) {
     $q_config[ $name ] = $val;
 }
 
-function qtranxf_load_option_array( $name, $default_value = null ) {
+function qtranxf_load_option_array( string $name, $default_value = null ): void {
     global $q_config;
     $vals = get_option( 'qtranslate_' . $name );
     if ( $vals === false ) {
@@ -292,7 +292,7 @@ function qtranxf_load_option_array( $name, $default_value = null ) {
     $q_config[ $name ] = $vals;
 }
 
-function qtranxf_load_option_bool( $name, $default_value = null ) {
+function qtranxf_load_option_bool( string $name, ?bool $default_value = null ): void {
     global $q_config;
     $val = get_option( 'qtranslate_' . $name );
     if ( $val === false ) {
@@ -327,7 +327,7 @@ function qtranxf_load_option_bool( $name, $default_value = null ) {
     }
 }
 
-function qtranxf_load_option_func( $name, $opn = null, $func = null ) {
+function qtranxf_load_option_func( string $name, string $opn = null, $func = null ): void {
     global $q_config;
     if ( ! $opn ) {
         $opn = 'qtranslate_' . $name;
@@ -342,7 +342,7 @@ function qtranxf_load_option_func( $name, $opn = null, $func = null ) {
     $q_config[ $name ] = $val;
 }
 
-function qtranxf_load_option_qtrans_compatibility() {
+function qtranxf_load_option_qtrans_compatibility(): void {
     global $q_config;
     qtranxf_load_option_bool( 'qtrans_compatibility', false );
     $q_config['qtrans_compatibility'] = apply_filters( 'qtranslate_compatibility', $q_config['qtrans_compatibility'] );
@@ -352,7 +352,7 @@ function qtranxf_load_option_qtrans_compatibility() {
     require_once QTRANSLATE_DIR . '/src/compatibility.php';
 }
 
-function qtranxf_load_plugin_textdomain() {
+function qtranxf_load_plugin_textdomain(): bool {
     if ( load_plugin_textdomain( 'qtranslate', false, basename( QTRANSLATE_DIR ) . '/lang' ) ) {
         return true;
     }
@@ -360,13 +360,13 @@ function qtranxf_load_plugin_textdomain() {
     return false;
 }
 
-function qtranxf_is_permalink_structure_query() {
+function qtranxf_is_permalink_structure_query(): bool {
     $permalink_structure = get_option( 'permalink_structure' );
 
     return empty( $permalink_structure ) || strpos( $permalink_structure, '?' ) !== false || strpos( $permalink_structure, 'index.php' ) !== false;
 }
 
-function qtranxf_front_header_css_default() {
+function qtranxf_front_header_css_default(): string {
     global $q_config;
     $flag_location = qtranxf_flag_location();
     $css           = '';
@@ -377,17 +377,17 @@ function qtranxf_front_header_css_default() {
     return $css;
 }
 
-function qtranxf_flag_location() {
+function qtranxf_flag_location(): string {
     global $q_config;
 
     return trailingslashit( content_url() ) . $q_config['flag_location'];
 }
 
-function qtranxf_flag_location_default() {
+function qtranxf_flag_location_default(): string {
     return qtranxf_plugin_dirname_from_wp_content() . '/flags/';
 }
 
-function qtranxf_load_option_flag_location( $nm ) {
+function qtranxf_load_option_flag_location( string $nm ): void {
     global $q_config;
     $default_value = qtranxf_flag_location_default();
     $option_value  = get_option( 'qtranslate_' . $nm );
@@ -405,7 +405,7 @@ function qtranxf_load_option_flag_location( $nm ) {
     }
 }
 
-function qtranxf_load_config() {
+function qtranxf_load_config(): void {
     global $qtranslate_options, $q_config;
     qtranxf_set_default_options( $qtranslate_options );
 

--- a/src/rest_api.php
+++ b/src/rest_api.php
@@ -13,7 +13,7 @@
  *
  * @see rest_api_register_rewrites in wp_includes/rest-api.php
  */
-function qtranxf_rest_api_register_rewrites() {
+function qtranxf_rest_api_register_rewrites(): void {
     global $q_config;
     if ( ! $q_config['hide_default_language'] || $q_config['url_mode'] !== QTX_URL_PATH ) {
         return;

--- a/src/taxonomy.php
+++ b/src/taxonomy.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 3.4.6.9
  *
  */
-function qtranxf_term_set_i18n_config( $term ) {
+function qtranxf_term_set_i18n_config( ?WP_Term $term ) {
     $term->i18n_config = array();
     if ( isset( $term->name ) ) {
         global $q_config;
@@ -31,7 +31,7 @@ function qtranxf_term_set_i18n_config( $term ) {
 /**
  * @since 3.4
  */
-function qtranxf_term_use( $lang, $obj, $taxonomy ) {
+function qtranxf_term_use( string $lang, $obj, $taxonomy ) {
     global $q_config;
     if ( is_array( $obj ) ) {
         // handle arrays recursively
@@ -72,7 +72,7 @@ function qtranxf_useTermLib( $obj ) {
  * @since 3.4.6.9
  *
  */
-function qtranxf_term_name_in( $lang, $term ) {
+function qtranxf_term_name_in( string $lang, WP_Term $term ): string {
     if ( isset( $term->i18n_config['name']['ts'][ $lang ] ) ) {
         return $term->i18n_config['name']['ts'][ $lang ];
     }

--- a/src/url.php
+++ b/src/url.php
@@ -12,7 +12,7 @@
  *
  * @return string
  */
-function qtranxf_convertURL( $url = '', $lang = '', $forceadmin = false, $showDefaultLanguage = false ) {
+function qtranxf_convertURL( string $url = '', string $lang = '', bool $forceadmin = false, bool $showDefaultLanguage = false ): string {
     global $q_config;
 
     if ( empty( $lang ) ) {
@@ -37,7 +37,7 @@ function qtranxf_convertURL( $url = '', $lang = '', $forceadmin = false, $showDe
     return $complete;
 }
 
-function qtranxf_convertURLs( $url, $lang = '', $forceadmin = false, $showDefaultLanguage = false ) {
+function qtranxf_convertURLs( $url, string $lang = '', bool $forceadmin = false, bool $showDefaultLanguage = false ) {
     global $q_config;
     if ( empty( $lang ) ) {
         $lang = $q_config['language'];
@@ -58,7 +58,7 @@ function qtranxf_convertURLs( $url, $lang = '', $forceadmin = false, $showDefaul
 /**
  * @since 3.0
  */
-function qtranxf_url_del_language( &$urlinfo ) {
+function qtranxf_url_del_language( array &$urlinfo ): void {
     global $q_config;
 
     if ( ! empty( $urlinfo['query'] ) ) {
@@ -107,7 +107,7 @@ function qtranxf_url_del_language( &$urlinfo ) {
     }
 }
 
-function qtranxf_url_set_language( $urlinfo, $lang, $showLanguage ) {
+function qtranxf_url_set_language( array $urlinfo, $lang, bool $showLanguage ): array {
     global $q_config;
     $urlinfo = qtranxf_copy_url_info( $urlinfo );
     if ( $showLanguage ) {
@@ -152,7 +152,7 @@ function qtranxf_url_set_language( $urlinfo, $lang, $showLanguage ) {
     return $urlinfo;
 }
 
-function qtranxf_get_url_for_language( $url, $lang, $showLanguage = true ) {
+function qtranxf_get_url_for_language( string $url, string $lang, bool $showLanguage = true ): string {
     global $q_config;
     static $url_cache = array();
     if ( ! isset( $url_cache[ $url ] ) ) {
@@ -254,7 +254,7 @@ function qtranxf_get_url_for_language( $url, $lang, $showLanguage = true ) {
 }
 
 // check if it is a link to an ignored file type
-function qtranxf_ignored_file_type( $path ) {
+function qtranxf_ignored_file_type( string $path ): bool {
     global $q_config;
     $i = strpos( $path, '?' );
     if ( $i !== false ) {
@@ -273,7 +273,7 @@ function qtranxf_ignored_file_type( $path ) {
     return in_array( $ext, $q_config['ignore_file_types'] );
 }
 
-function qtranxf_language_neutral_path( $path ) {
+function qtranxf_language_neutral_path( string $path ): bool {
     if ( empty( $path ) ) {
         return false;
     }
@@ -299,7 +299,7 @@ function qtranxf_language_neutral_path( $path ) {
 /*
  * @since 2.3.8 simplified version of esc_url
  */
-function qtranxf_sanitize_url( $url ) {
+function qtranxf_sanitize_url( string $url ): string {
     $url   = preg_replace( '|[^a-z0-9-~+_.?#=!&;,/:%@$\|*\'()\[\]\\x80-\\xff]|i', '', $url );
     $strip = array( '%0d', '%0a', '%0D', '%0A' );
     do {
@@ -310,7 +310,7 @@ function qtranxf_sanitize_url( $url ) {
 }
 
 
-function qtranxf_get_url_info( $url ) {
+function qtranxf_get_url_info( string $url ): array {
     $urlinfo = qtranxf_parseURL( $url );
     qtranxf_complete_url_info( $urlinfo );
     qtranxf_complete_url_info_path( $urlinfo );
@@ -324,7 +324,7 @@ function qtranxf_get_url_info( $url ) {
  *
  * @param array $urlinfo
  */
-function qtranxf_complete_url_info( &$urlinfo ) {
+function qtranxf_complete_url_info( array &$urlinfo ): void {
     if ( ! isset( $urlinfo['path'] ) ) {
         $urlinfo['path'] = '';
     }
@@ -367,7 +367,7 @@ function qtranxf_complete_url_info( &$urlinfo ) {
  *
  * @since 3.2.8
  */
-function qtranxf_complete_url_info_path( &$urlinfo ) {
+function qtranxf_complete_url_info_path( array &$urlinfo ): void {
     if ( isset( $urlinfo['path-base'] ) ) {
         if ( empty( $urlinfo['path-base'] ) ) {
             $urlinfo['wp-path'] = $urlinfo['path'];
@@ -384,7 +384,7 @@ function qtranxf_complete_url_info_path( &$urlinfo ) {
     }
 }
 
-function qtranxf_parseURL( $url ) {
+function qtranxf_parseURL( string $url ): array {
     // this is not the same as native parse_url and so it is in use
     // it should also work quicker than native parse_url, so we should keep it?
     preg_match( '!(?:(\w+)://)?(?:(\w+):(\w+)@)?([^/:?#]+)?(?::(\d*))?([^#?]+)?(?:\?([^#]+))?(?:#(.+$))?!', $url, $out );
@@ -420,7 +420,7 @@ function qtranxf_parseURL( $url ) {
 /**
  * @since 3.2.8
  */
-function qtranxf_buildURL( $urlinfo, $homeinfo ) {
+function qtranxf_buildURL( array $urlinfo, array $homeinfo ): string {
     if ( empty( $urlinfo['host'] ) ) {
         $url = ''; // relative path stays relative
     } else {
@@ -459,7 +459,7 @@ function qtranxf_buildURL( $urlinfo, $homeinfo ) {
 /**
  * @since 3.2.8 Copies the data needed for qtranxf_buildURL and qtranxf_url_set_language
  */
-function qtranxf_copy_url_info( $urlinfo ) {
+function qtranxf_copy_url_info( array $urlinfo ): array {
     $copy = array();
     if ( isset( $urlinfo['scheme'] ) ) {
         $copy['scheme'] = $urlinfo['scheme'];
@@ -492,7 +492,7 @@ function qtranxf_copy_url_info( $urlinfo ) {
     return $copy;
 }
 
-function qtranxf_external_host_ex( $host, $homeinfo ) {
+function qtranxf_external_host_ex( string $host, array $homeinfo ): bool {
     global $q_config;
 
     switch ( $q_config['url_mode'] ) {
@@ -517,13 +517,13 @@ function qtranxf_external_host_ex( $host, $homeinfo ) {
     }
 }
 
-function qtranxf_external_host( $host ) {
+function qtranxf_external_host( string $host ): bool {
     $homeinfo = qtranxf_get_home_info();
 
     return qtranxf_external_host_ex( $host, $homeinfo );
 }
 
-function qtranxf_get_page_referer() {
+function qtranxf_get_page_referer(): string {
     if ( wp_doing_ajax() ) {
         global $q_config;
         if ( isset( $q_config['url_info']['page_referer'] ) ) {

--- a/src/utils.php
+++ b/src/utils.php
@@ -590,11 +590,11 @@ function qtranxf_remove_filters( $filters ) {
 /**
  * @since 3.4
  */
-function qtranxf_html_locale( $locale ) {
+function qtranxf_html_locale( string $locale ): string {
     return str_replace( '_', '-', $locale );
 }
 
-function qtranxf_match_language_locale( $locale ) {
+function qtranxf_match_language_locale( string $locale ): ?string {
     global $q_config;
     foreach ( $q_config['enabled_languages'] as $lang ) {
         if ( qtranxf_html_locale( $q_config['locale'][ $lang ] ) == $locale ) {

--- a/src/widget.php
+++ b/src/widget.php
@@ -39,7 +39,7 @@ class qTranslateXWidget extends WP_Widget {
         parent::__construct( 'qtranslate', __( 'qTranslate Language Chooser', 'qtranslate' ), $widget_ops );
     }
 
-    function widget( $args, $instance ) {
+    function widget( $args, $instance ): void {
         if ( ! isset( $instance['widget-css-off'] ) ) {
             echo '<style>' . PHP_EOL;
             echo empty( $instance['widget-css'] ) ? QTX_WIDGET_CSS : $instance['widget-css'];
@@ -61,7 +61,7 @@ class qTranslateXWidget extends WP_Widget {
         echo $args['after_widget'];
     }
 
-    function update( $new_instance, $old_instance ) {
+    function update( $new_instance, $old_instance ): array {
         $instance          = $old_instance;
         $instance['title'] = $new_instance['title'];
 
@@ -100,8 +100,8 @@ class qTranslateXWidget extends WP_Widget {
         return $instance;
     }
 
-    function form( $instance ) {
-        $instance         = wp_parse_args( (array) $instance, array(
+    function form( $instance ): void {
+        $instance         = wp_parse_args( $instance, array(
             'title'      => '',
             'type'       => 'text',
             'format'     => '',


### PR DESCRIPTION
PHP type declarations make the code clearer and catch some bugs due to wrong calls not handled properly.
PHP7.1 is interesting for nullable args and void return values.
See [PHP type declarations](https://www.php.net/manual/en/language.types.declarations.php).

This patch covers all of the qTranslate code.
Though it doesn't enforce strict checks yet, this has little effect with array and strings.
These changes might break some parts in specific situations so it should be tested by developers in `master`.
Some types are left unspecified, as mixed types require PHP 8.0 and some WP/plugin APIs are unclear.
