### PR TITLE
Lint PHP by simplifying expressions

### DIFF
--- a/src/admin/activation_hook.php
+++ b/src/admin/activation_hook.php
@@ -607,8 +607,7 @@ function qtranxf_add_config_file( array $config_files, string $add_file ): array
 function qtranxf_add_config_files( array &$config_files, array $add_files ): bool {
     $changed = false;
     foreach ( $add_files as $file ) {
-        $index = array_search( $file, $config_files );
-        if ( $index !== false ) {
+        if ( ! in_array( $file, $config_files ) ) {
             continue;
         }
         $config_files = qtranxf_add_config_file( $config_files, $file );

--- a/src/admin/admin.php
+++ b/src/admin/admin.php
@@ -22,7 +22,7 @@ function qtranxf_collect_translations_deep( $qfields, string $sep ) {
     // collect recursively
     foreach ( $content as $f => $r ) {
         $texts = array();
-        foreach ( $qfields as $lang => &$vals ) {
+        foreach ( $qfields as $lang => $vals ) {
             $texts[ $lang ] = $vals[ $f ];
         }
         $result[ $f ] = qtranxf_collect_translations_deep( $texts, $sep );
@@ -48,11 +48,9 @@ function qtranxf_collect_translations( array &$qfields, &$request, string $edit_
             // convert to ML value
             $qfields[ $edit_lang ] = $request;
             $request               = qtranxf_collect_translations_deep( $qfields, $sep );
-        } else {
-            // raw mode, or user mistakenly put ML value into an LSB-controlled field
-            // leave request as user entered it
-            return;
         }
+        // Otherwise: raw mode, or user mistakenly put ML value into an LSB-controlled field.
+        // Leave request as user entered it.
     } else {
         foreach ( $qfields as $name => &$values ) {
             if ( ! isset( $request[ $name ] ) ) {
@@ -374,6 +372,8 @@ function qtranxf_admin_footer() {
     wp_deregister_script( 'autosave' );
 
     $config = array();
+    $config['page_config'] = $page_config;
+    unset( $config['page_config']['js'] );  // No need for javascript.
     // TODO missing 'term_name' ?
     $keys = array(
         'default_language',
@@ -414,11 +414,6 @@ function qtranxf_admin_footer() {
         $lang_cfg['locale_html']  = ! empty( $q_config['locale_html'][ $lang ] ) ? $q_config['locale_html'][ $lang ] : $lang;
         $lang_cfg['admin_name']   = qtranxf_getLanguageName( $lang );
     }
-    if ( ! empty( $page_config ) ) {
-        $config['page_config'] = $page_config;
-        // no need for javascript
-        unset( $config['page_config']['js'] );
-    }
 
     // For Gutenberg, enforce the editor mode to QTX_EDITOR_MODE_SINGLE
     $current_screen = get_current_screen();
@@ -454,7 +449,7 @@ function qtranxf_admin_footer() {
         echo 'var qTranslateConfig=' . json_encode( $config ) . ';' . PHP_EOL;
         // each script entry may define javascript code to be injected
         foreach ( $page_config['js'] as $js ) {
-            if ( isset( $js['javascript'] ) && ! empty( $js['javascript'] ) ) {
+            if ( ! empty( $js['javascript'] ) ) {
                 echo $js['javascript'];
             }
         }
@@ -627,6 +622,7 @@ function qtranxf_nav_menu_metabox( $object ) {
         public $menu_item_parent = 0;
         public $type = 'custom';
         public $title;// = 'Language';
+        public $label;
         public $url;
         public $target = '';
         public $attr_title = '';

--- a/src/admin/admin_options_update.php
+++ b/src/admin/admin_options_update.php
@@ -813,7 +813,7 @@ function qtranxf_update_settings(): void {
         if ( ! isset( $_POST[ $id ] ) ) {
             continue;
         }
-        $domain           = preg_replace( '#^/*#', '', untrailingslashit( trim( $_POST[ $id ] ) ) );
+        $domain           = trim( $_POST[ $id ], " /" );
         $domains[ $lang ] = $domain;
     }
     if ( ! empty( $domains ) && ( ! isset( $q_config['domains'] ) || ! qtranxf_array_compare( $q_config['domains'], $domains ) ) ) {

--- a/src/admin/admin_settings.php
+++ b/src/admin/admin_settings.php
@@ -781,7 +781,7 @@ class QTX_Admin_Settings {
                 <td><label for="qtranxs_config_files"
                            class="qtranxs_explanation"><?php printf( __( 'List of configuration files. Unless prefixed with "%s", paths are relative to %s variable: %s. Absolute paths are also acceptable.', 'qtranslate' ), './', 'WP_CONTENT_DIR', trailingslashit( WP_CONTENT_DIR ) ) ?></label>
                     <br/><textarea name="json_config_files" id="qtranxs_config_files" rows="4"
-                                   style="width:100%"><?php echo isset( $_POST['json_config_files'] ) ? $_POST['json_config_files'] /* already sanitized */ : implode( PHP_EOL, $q_config['config_files'] ) ?></textarea>
+                                   style="width:100%"><?php echo $_POST['json_config_files'] ?? implode( PHP_EOL, $q_config['config_files'] ) ?></textarea>
                     <p class="qtranxs-notes"><?php printf( __( 'The list gets auto-updated on a 3rd-party integrated plugin activation/deactivation. You may also add your own custom files for your theme or plugins. File "%s" is the default configuration loaded from this plugin folder. It is not recommended to modify any configuration file from other authors, but you may alter any configuration item through your own custom file appended to the end of this list.', 'qtranslate' ), './i18n-config.json' );
                         echo ' ';
                         printf( __( 'Use "%s" to review the resulting combined configuration from all "%s" and this option.', 'qtranslate' ), '<a href="' . $this->options_uri . '&config_inspector=show' . '">' . __( 'Configuration Inspector', 'qtranslate' ) . '</a>', __( 'Custom Configuration', 'qtranslate' ) );

--- a/src/admin/admin_settings_language_list.php
+++ b/src/admin/admin_settings_language_list.php
@@ -59,13 +59,8 @@ class QTX_Admin_Settings_Language_List extends WP_List_Table {
             } else {
                 $flag_url = $flag_location_url_def . $flag;
             }
-            $flag_item = '<img src="' . $flag_url . '" alt="' . sprintf( __( '%s Flag', 'qtranslate' ), $language ) . '">';
-
-            if ( isset( $q_config['locale'][ $lang ] ) ) {
-                $locale_item = $q_config['locale'][ $lang ];
-            } else {
-                $locale_item = $locales[ $lang ] ?? '?';
-            }
+            $flag_item   = '<img src="' . $flag_url . '" alt="' . sprintf( __( '%s Flag', 'qtranslate' ), $language ) . '">';
+            $locale_item = $q_config['locale'][ $lang ] ?? $locales[ $lang ] ?? '?';
 
             $icon_enable  = 'dashicons dashicons-insert';
             $icon_disable = 'dashicons dashicons-remove';
@@ -73,12 +68,11 @@ class QTX_Admin_Settings_Language_List extends WP_List_Table {
                 if ( $q_config['default_language'] == $lang ) {
                     $status = '<span class="dashicons dashicons-star-filled" title="' . esc_attr( __( 'Default', 'qtranslate' ) ) . '"></span>';
                     $action = '<span class="disabled ' . $icon_disable . '"></span>';
-                    $action .= '<span class="disabled ' . $icon_enable . '"></span>';
                 } else {
                     $status = '<span class="dashicons dashicons-star-empty" title="' . esc_attr( __( 'Enabled', 'qtranslate' ) ) . '"></span>';
                     $action = '<a class="edit" href="' . $options_uri . '&disable=' . $lang . '#languages" title="' . esc_attr( __( 'Disable', 'qtranslate' ) ) . '"><span class="' . $icon_disable . '"></span></a>';
-                    $action .= '<span class="disabled ' . $icon_enable . '"></span>';
                 }
+                $action .= '<span class="disabled ' . $icon_enable . '"></span>';
             } else {
                 $status = '';
                 $action = '<span class="disabled ' . $icon_disable . '"></span>';

--- a/src/admin/admin_utils_db.php
+++ b/src/admin/admin_utils_db.php
@@ -362,21 +362,15 @@ function qtranxf_split_database_file( string $ifp, array $languages_to_keep ): s
                     fflush( $dfh );
                     copy( $dfp, $lfp );
                     $lfh = fopen( $lfp, 'a+' );
-                    if ( ! $lfh || ! $dfh ) {
+                    if ( ! $lfh ) {
                         fclose( $ifh );
-                        foreach ( $files as &$file ) {
+                        foreach ( $files as $file ) {
                             if ( ! isset( $file['fh'] ) ) {
                                 continue;
                             }
                             fclose( $file['fh'] );
                         }
-                        if ( ! $lfh ) {
-                            $errors[] = sprintf( __( 'Failed to open output database file "%s"', 'qtranslate' ), $lfp );
-                        }
-                        if ( ! $dfh ) {
-                            $errors[] = sprintf( __( 'Failed to re-open output database file "%s"', 'qtranslate' ), $dfp );
-                        }
-
+                        $errors[] = sprintf( __( 'Failed to open output database file "%s"', 'qtranslate' ), $lfp );
                         return '';
                     }
                     $files[ $lang ] = array( 'fp' => $lfp, 'fh' => $lfh );
@@ -407,7 +401,7 @@ function qtranxf_split_database_file( string $ifp, array $languages_to_keep ): s
         }
     }
     fclose( $ifh );
-    foreach ( $files as &$file ) {
+    foreach ( $files as $file ) {
         fclose( $file['fh'] );
     }
     if ( $mfh ) {
@@ -534,7 +528,7 @@ function qtranxf_db_clean_terms(): string {
                     break;
                 }
             }
-        } else if ( isset( $term_name_cur[ $nm ] ) && is_array( $term_name_cur[ $nm ] ) && ! empty( $term_name_cur[ $nm ] ) ) {
+        } else if ( ! empty( $term_name_cur[ $nm ] ) && is_array( $term_name_cur[ $nm ] ) ) {
             $ts = $term_name_cur[ $nm ];
         } else {
             continue;

--- a/src/admin/block_editor.php
+++ b/src/admin/block_editor.php
@@ -195,18 +195,17 @@ class QTX_Admin_Block_Editor {
      */
     private function select_raw_response_language( $response, string $editor_lang ) {
         $response_data = $response->get_data();
-        if ( isset( $response_data['content'] ) && is_array( $response_data['content'] ) && isset( $response_data['content']['raw'] ) ) {
-            $response_data['title']['raw']   = qtranxf_use( $editor_lang, $response_data['title']['raw'], false, true );
-            $response_data['content']['raw'] = qtranxf_use( $editor_lang, $response_data['content']['raw'], false, true );
-
-            if ( isset( $response_data['excerpt']['raw'] ) ) {
-                $response_data['excerpt']['raw'] = qtranxf_use( $editor_lang, $response_data['excerpt']['raw'], false, true );
-            }
-
-            $response_data['qtx_editor_lang'] = $editor_lang;
-            $response->set_data( $response_data );
+        if ( isset( $response_data['title']['raw'] ) ) {
+            $response_data['title']['raw'] = qtranxf_use( $editor_lang, $response_data['title']['raw'], false, true );
         }
-
+        if ( isset( $response_data['content']['raw'] ) ) {
+            $response_data['content']['raw'] = qtranxf_use( $editor_lang, $response_data['content']['raw'], false, true );
+        }
+        if ( isset( $response_data['excerpt']['raw'] ) ) {
+            $response_data['excerpt']['raw'] = qtranxf_use( $editor_lang, $response_data['excerpt']['raw'], false, true );
+        }
+        $response_data['qtx_editor_lang'] = $editor_lang;
+        $response->set_data( $response_data );
         return $response;
     }
 

--- a/src/date_time.php
+++ b/src/date_time.php
@@ -39,20 +39,19 @@ function qxtranxf_intl_strftime( string $format, $timestamp = null, ?string $loc
 
     $locale = substr( (string) $locale, 0, 5 );
 
-    $intl_formats = [
-        '%a' => 'EEE',    // An abbreviated textual representation of the day	Sun through Sat
-        '%A' => 'EEEE',    // A full textual representation of the day	Sunday through Saturday
-        '%b' => 'MMM',    // Abbreviated month name, based on the locale	Jan through Dec
-        '%B' => 'MMMM',    // Full month name, based on the locale	January through December
-        '%h' => 'MMM',    // Abbreviated month name, based on the locale (an alias of %b)	Jan through Dec
-    ];
-
     // \DateTimeInterface, string
-    $intl_formatter = function ( DateTimeInterface $timestamp, string $format ) use ( $intl_formats, $locale ) {
-        $tz        = $timestamp->getTimezone();
-        $date_type = \IntlDateFormatter::FULL;
-        $time_type = \IntlDateFormatter::FULL;
-        $pattern   = '';
+    $intl_formatter = function ( DateTimeInterface $timestamp, string $format ) use ( $locale ) {
+        $intl_formats = [
+            '%a' => 'EEE',    // An abbreviated textual representation of the day	Sun through Sat
+            '%A' => 'EEEE',    // A full textual representation of the day	Sunday through Saturday
+            '%b' => 'MMM',    // Abbreviated month name, based on the locale	Jan through Dec
+            '%B' => 'MMMM',    // Full month name, based on the locale	January through December
+            '%h' => 'MMM',    // Abbreviated month name, based on the locale (an alias of %b)	Jan through Dec
+        ];
+        $tz           = $timestamp->getTimezone();
+        $date_type    = \IntlDateFormatter::FULL;
+        $time_type    = \IntlDateFormatter::FULL;
+        $pattern      = '';
 
         // %c = Preferred date and time stamp based on locale
         // Example: Tue Feb 5 00:45:10 2009 for February 5, 2009 at 12:45:10 AM

--- a/src/frontend.php
+++ b/src/frontend.php
@@ -105,11 +105,7 @@ function qtranxf_wp_get_nav_menu_items( $items, $menu, $args ) {
                         case 'taxonomy':
                             $term = wp_cache_get( $item->object_id, $item->object );
                             if ( $term ) {
-                                if ( isset( $q_config['term_name'][ $term->name ][ $language ] ) ) {
-                                    $item_title = $q_config['term_name'][ $term->name ][ $language ];
-                                } else {
-                                    $item_title = '';
-                                }
+                                $item_title = $q_config['term_name'][ $term->name ][ $language ] ?? '';
                                 if ( ! empty( $term->description ) ) {
                                     $item->description = $term->description;
                                 }
@@ -568,7 +564,7 @@ function qtranxf_excludeUntranslatedAdjacentPosts( $where ): string {
     return $where;
 }
 
-function qtranxf_excludeUntranslatedPosts( $where, $query ) {//WP_Query
+function qtranxf_excludeUntranslatedPosts( $where, $query ) {  // WP_Query
     switch ( $query->query_vars['post_type'] ) {
         //known not to filter
         case 'nav_menu_item':
@@ -581,17 +577,9 @@ function qtranxf_excludeUntranslatedPosts( $where, $query ) {//WP_Query
         default:
             break;
     }
-    $single_post_query = $query->is_singular();//since 3.1 instead of top is_singular()
-    while ( ! $single_post_query ) {
-        $single_post_query = preg_match( '/ID\s*=\s*[\'"]*(\d+)[\'"]*/i', $where, $matches ) == 1;
-        if ( $single_post_query ) {
-            break;
-        }
-        $single_post_query = preg_match( '/post_name\s*=\s*[^\s]+/i', $where, $matches ) == 1;
-        break;
-    }
-
-    if ( ! $single_post_query ) {
+    if ( ! $query->is_singular() &&
+         preg_match( '/ID\s*=\s*[\'"]*(\d+)[\'"]*/i', $where, $matches ) != 1 &&
+         preg_match( '/post_name\s*=\s*\S+/i', $where, $matches ) != 1 ) {
         global $wpdb;
         $lang  = qtranxf_getLanguage();
         $where .= ' AND ' . qtranxf_where_clause_translated_posts( $lang, $wpdb->posts );
@@ -600,11 +588,11 @@ function qtranxf_excludeUntranslatedPosts( $where, $query ) {//WP_Query
     return $where;
 }
 
-function qtranxf_excludeUntranslatedPostComments( $clauses, $q/*WP_Comment_Query*/ ) {
+function qtranxf_excludeUntranslatedPostComments( $clauses, $q /*WP_Comment_Query*/ ) {
     global $wpdb;
 
 
-    if ( ! isset( $clauses['join'] ) || empty( $clauses['join'] ) ) {
+    if ( empty( $clauses['join'] ) ) {
         $clauses['join'] = "JOIN $wpdb->posts ON $wpdb->posts.ID = $wpdb->comments.comment_post_ID";
     } elseif ( strpos( $clauses['join'], $wpdb->posts ) === false ) {
         //do not break some more complex JOIN if it ever happens

--- a/src/language_blocks.php
+++ b/src/language_blocks.php
@@ -455,7 +455,7 @@ function qtranxf_use_content( string $lang, $content, array $available_langs, bo
 
     $msg    = preg_replace( '/%LANG:([^:]*):([^%]*)%/', $language_list, $q_config['not_available'][ $lang ] );
     $output = '<p class="qtranxs-available-languages-message qtranxs-available-languages-message-' . $lang . '">' . $msg . '</p>';
-    if ( ! empty( $q_config['show_alternative_content'] ) && $q_config['show_alternative_content'] ) {
+    if ( ! empty( $q_config['show_alternative_content'] ) ) {
         $output .= $alt_content;
     }
 

--- a/src/modules/slugs/admin_migrate_qts.php
+++ b/src/modules/slugs/admin_migrate_qts.php
@@ -49,9 +49,6 @@ function qtranxf_slugs_check_migrate_qts(): string {
 function qtranxf_slugs_migrate_qts_meta( bool $db_commit ): string {
     global $wpdb;
 
-    $new_prefix = QTX_SLUGS_META_PREFIX;
-    $old_prefix = QTX_SLUGS_LEGACY_QTS_META_PREFIX;
-
     /**
      * Generic function that migrates QTS meta to QTX meta.
      *
@@ -62,7 +59,9 @@ function qtranxf_slugs_migrate_qts_meta( bool $db_commit ): string {
      *
      * @return void
      */
-    $migrate_meta = function ( string $table, string $colid, bool $db_commit, array &$msg ) use ( $wpdb, $old_prefix, $new_prefix ): void {
+    $migrate_meta = function ( string $table, string $colid, bool $db_commit, array &$msg ) use ( $wpdb ): void {
+        $new_prefix = QTX_SLUGS_META_PREFIX;
+        $old_prefix = QTX_SLUGS_LEGACY_QTS_META_PREFIX;
         // Escape '_' against LIKE wildcards.
         $old_esc = str_replace( '_', '\_', $old_prefix );
         $new_esc = str_replace( '_', '\_', $new_prefix );

--- a/src/options.php
+++ b/src/options.php
@@ -185,11 +185,7 @@ function qtranxf_language_configured( string $prop, ?string $opn = null ) {
     global $qtranslate_options;
     $val = call_user_func( 'qtranxf_default_' . $prop );
     if ( ! $opn ) {
-        if ( isset( $qtranslate_options['languages'][ $prop ] ) ) {
-            $opn = $qtranslate_options['languages'][ $prop ];
-        } else {
-            $opn = 'qtranslate_' . $prop;
-        }
+        $opn = $qtranslate_options['languages'][ $prop ] ?? 'qtranslate_' . $prop;
     }
     $opt = get_option( $opn, array() );
     if ( $opt ) {

--- a/src/taxonomy.php
+++ b/src/taxonomy.php
@@ -35,8 +35,8 @@ function qtranxf_term_use( string $lang, $obj, $taxonomy ) {
     global $q_config;
     if ( is_array( $obj ) ) {
         // handle arrays recursively
-        foreach ( $obj as $key => $t ) {
-            $obj[ $key ] = qtranxf_term_use( $lang, $obj[ $key ], $taxonomy );
+        foreach ( $obj as $key => $term ) {
+            $obj[ $key ] = qtranxf_term_use( $lang, $term, $taxonomy );
         }
 
         return $obj;

--- a/src/url.php
+++ b/src/url.php
@@ -436,7 +436,7 @@ function qtranxf_buildURL( array $urlinfo, array $homeinfo ): string {
             }
             $url .= '@';
         }
-        $url .= empty( $urlinfo['host'] ) ? $homeinfo['host'] : $urlinfo['host'];
+        $url .= $urlinfo['host'];
     }
     if ( ! empty( $urlinfo['path-base'] ) ) {
         $url .= $urlinfo['path-base'];


### PR DESCRIPTION
Use null coalesce operator.
Remove unnecessary checks and references.
Refactor `select_raw_response_language` for each raw entry.
Refactor `qtranxf_excludeUntranslatedPosts` without fake `while` loop.
Misc improvements.