### PR TITLE
Rename `QTX_Translator::translate_{item}`  filters

### DIFF
--- a/dev/qtx-tests.php
+++ b/dev/qtx-tests.php
@@ -18,23 +18,17 @@ function qtranxf_check_test( $result, $expected, $test_name ) {
 }
 
 function qtranxf_test_interface() {
-    $t = apply_filters( 'wp_translator', null );
-    qtranxf_tst_log( 'qtranxf_test_interface: $t: ', $t );
-
-    $text = apply_filters( 'translate_text', '[:en](EN)text[:de](DE)text[:]' );
+    $text = apply_filters( 'qtranslate_text', '[:en](EN)text[:de](DE)text[:]' );
     qtranxf_tst_log( 'qtranxf_test_interface: $text: ', $text );
 
-    $text = apply_filters( 'translate_text', '[:en](EN)text[:de](DE)text[:]', 'de' );
+    $text = apply_filters( 'qtranslate_text', '[:en](EN)text[:de](DE)text[:]', 'de' );
     qtranxf_check_test( $text, '(DE)text', 'qtranxf_test_interface: translate_text' );
 
-    $url = apply_filters( 'translate_url', '' );
+    $url = apply_filters( 'qtranslate_url', '' );
     qtranxf_tst_log( 'qtranxf_test_interface: $url: ', $url );
 
-    $term = apply_filters( 'translate_term', '(EN) Cat1' );
+    $term = apply_filters( 'qtranslate_term', '(EN) Cat1' );
     qtranxf_tst_log( 'qtranxf_test_interface: $term: ', $term );
-
-    $mlterm = apply_filters( 'multilingual_term', '(EN) Cat1' );
-    qtranxf_tst_log( 'qtranxf_test_interface: $mlterm: ', $mlterm );
 }
 
 function qtranxf_test_meta_cache() {

--- a/src/class_translator.php
+++ b/src/class_translator.php
@@ -12,9 +12,9 @@ require_once QTRANSLATE_DIR . '/src/translator_interface.php';
  */
 class QTX_Translator implements QTX_Translator_Interface {
     public function __construct() {
-        add_filter( 'translate_text', array( $this, 'translate_text' ), 10, 3 );
-        add_filter( 'translate_term', array( $this, 'translate_term' ), 10, 3 );
-        add_filter( 'translate_url', array( $this, 'translate_url' ), 10, 2 );
+        add_filter( 'qtranslate_text', array( $this, 'translate_text' ), 10, 3 );
+        add_filter( 'qtranslate_term', array( $this, 'translate_term' ), 10, 3 );
+        add_filter( 'qtranslate_url', array( $this, 'translate_url' ), 10, 2 );
         // TODO what about 'translate_date' and 'translate_time'?
     }
 

--- a/src/translator_interface.php
+++ b/src/translator_interface.php
@@ -16,27 +16,22 @@ const QTX_TRANSLATOR_SHOW_EMPTY     = 4;
  * It is recommended to only use the functions listed here when developing a 3rd-party integration.
  * It is not recommended to access global variables directly.
  *
- * Each method declared here is connected to a filter with the same name.
+ * Each `translate_{item}` method declared here is connected to a filter with the same item name.
  * For example, to call 'translate_text', one may use the following line of code:
  *
- *   $text = apply_filters('translate_text', $text, $lang, $flags);
+ *   $text = apply_filters('qtranslate_text', $text, $lang, $flags);
  *
  * where arguments $lang and $flags may be omitted.
  *
  * If a translating plugin is not loaded, the variable $text will not be altered, otherwise it may get translated, if applicable. This is a safe and easy way to integrate your plugin or theme with a translating plugin.
  *
- * Use test 'if($translator)' to determine if a translating plugin was loaded and to fork your code accordingly. However, it only makes sense to do, if your plugin requires presence of a translating plugin, otherwise apply_filters method of calling the interface functions is easier to employ.
- *
  * Below is the list of all available filter calls, printed here for the sake of convenience for a developer to copy and paste.
  *
  * Available at both, front- and admin-side:
  *
- *   $lang = apply_filters('get_language', $lang=null);
- *   $lang = apply_filters('set_language', $lang);
- *
- *   $text = apply_filters('translate_text', $text, $lang=null, $flags=0);
- *   $term = apply_filters('translate_term', $term, $lang=null, $taxonomy=null);
- *   $url  = apply_filters('translate_url', $url, $lang=null);
+ *   $text = apply_filters('qtranslate_text', $text, $lang=null, $flags=0);
+ *   $term = apply_filters('qtranslate_term', $term, $lang=null, $taxonomy=null);
+ *   $url  = apply_filters('qtranslate_url', $url, $lang=null);
  *
  * @since 3.4
  */
@@ -89,5 +84,4 @@ interface QTX_Translator_Interface {
      * @param string|null $lang (optional) A two-letter language code of the language to encode $url with. If omitted or null, then the currently active language is assumed.
      */
     public function translate_url( $url, ?string $lang = null ): string;
-
 }


### PR DESCRIPTION
All filters of qTranslate-XT should have a `qtranslate` suffix. Rename to `qtranslate_{item}`.

These filters are never used internally.
This class was meant to facilitate 3rd-party integration but it doesn't feel justified anymore, as developers are more inclined to call `qtranxf_use*` functions directly.
Before removing that class the official API should be clarified.