### PR TITLE
[SLUGS] misc fixes

### DIFF
--- a/src/modules/slugs/slugs.php
+++ b/src/modules/slugs/slugs.php
@@ -528,27 +528,30 @@ class QTX_Module_Slugs {
      * @return string Home url link with optional path appended.
      */
     public function home_url( string $url, string $path, ?string $scheme, ?int $blog_id ): string {
-        if ( ! in_array( $scheme, array( 'http', 'https' ) ) ) {
+        if ( ! isset($scheme) ){
             $scheme = is_ssl() && ! is_admin() ? 'https' : 'http';
         }
 
-        if ( empty( $blog_id ) || ! is_multisite() ) {
-            $url = get_option( 'home' );
-        } else {
-            $url = get_blog_option( $blog_id, 'home' );
+        if ( $scheme === 'rest' ) {
+                return $url;
+
+        } elseif ( $scheme !== 'relative' ) {
+            if ( empty( $blog_id ) || ! is_multisite() ) {
+                $url = get_option( 'home' );
+            } else {
+                $url = get_blog_option( $blog_id, 'home' );
+            }
+
+            if ( 'http' != $scheme ) {
+                $url = str_replace( 'http://', "$scheme://", $url );
+            }
+
+            if ( ! empty( $path ) && is_string( $path ) && strpos( $path, '..' ) === false ) {
+                $url .= '/' . ltrim( $path, '/' );
+            }
         }
 
-        if ( 'http' != $scheme ) {
-            $url = str_replace( 'http://', "$scheme://", $url );
-        }
-
-        $ignore_caller = $this->ignore_rewrite_caller();
-
-        if ( ! empty( $path ) && is_string( $path ) && strpos( $path, '..' ) === false ) {
-            $url .= '/' . ltrim( $path, '/' );
-        }
-
-        if ( ! $ignore_caller ) {
+        if ( ! $this->ignore_rewrite_caller() ) {
             $url = qtranxf_convertURL( $url, $this->get_temp_lang(), true );
         }
 

--- a/src/modules/slugs/slugs.php
+++ b/src/modules/slugs/slugs.php
@@ -365,17 +365,17 @@ class QTX_Module_Slugs {
         }
 
         // -> home url
-        if ( empty( $query ) || isset( $query['error'] ) ):
+        if ( empty( $query ) || isset( $query['error'] ) ) {
             $function = 'home_url';
             $id       = '';
 
         // -> search
-        elseif ( isset( $query['s'] ) ):
+        } elseif ( isset( $query['s'] ) ) {
             $id       = $query['s'];
             $function = "get_search_link";
 
         // -> page
-        elseif ( isset( $query['pagename'] ) || isset( $query['page_id'] ) ):
+        } elseif ( isset( $query['pagename'] ) || isset( $query['page_id'] ) ){
             $page = get_transient( 'qtranslate_slugs_matched_page' );
             if ( $page === false ) {
                 $page = isset( $query['page_id'] ) ? get_post( $query['page_id'] ) : $this->get_page_by_path( $query['pagename'] );
@@ -391,7 +391,7 @@ class QTX_Module_Slugs {
 
         // -> category
         // If 'name' key is defined, query is relevant to a post with a /%category%/%postname%/ permalink structure and will be captured later.
-        elseif ( ( ( isset( $query['category_name'] ) || isset( $query['cat'] ) ) && ! isset( $query['name'] ) ) ):
+        } elseif ( ( isset( $query['category_name'] ) || isset( $query['cat'] ) ) && ! isset( $query['name'] ) ) {
             if ( isset( $query['category_name'] ) ) {
                 $term_slug = $this->get_last_slash( empty( $query['category_name'] ) ? $wp->request : $query['category_name'] );
                 $term      = $this->get_term_by( 'slug', $term_slug, 'category' );
@@ -408,7 +408,7 @@ class QTX_Module_Slugs {
             }
 
         // -> tag
-        elseif ( isset( $query['tag'] ) ):
+        } elseif ( isset( $query['tag'] ) ) {
             $term = $this->get_term_by( 'slug', $query['tag'], 'post_tag' );
             if ( $term ) {
                 $cache_array = array( $term );
@@ -418,7 +418,7 @@ class QTX_Module_Slugs {
                 $function     = 'get_tag_link';
             }
 
-        else:
+        } else {
 
             // If none of the conditions above are matched, specific tests to identify custom post types and taxonomies are performed here.
 
@@ -450,7 +450,7 @@ class QTX_Module_Slugs {
             }
 
             // -> taxonomy
-            foreach ( $this->get_public_taxonomies() as $item ):
+            foreach ( $this->get_public_taxonomies() as $item ) {
                 if ( isset( $query[ $item->name ] ) ) {
                     $term_slug = $this->get_last_slash( empty( $query[ $item->name ] ) ? $wp->request : $query[ $item->name ] );
                     $term      = $this->get_term_by( 'slug', $term_slug, $item->name );
@@ -462,7 +462,7 @@ class QTX_Module_Slugs {
                         $function             = 'get_term_link';
                     }
                 }
-            endforeach;
+            }
 
             /* As 'name' key is present also at least both for pages and custom post types, this condition alone cannot be used to identify uniquely the posts.
              * For pages and custom post types specific tests can be and are performed earlier but no additional specific condition seems to be applicable for posts.
@@ -481,7 +481,7 @@ class QTX_Module_Slugs {
                     $function = 'get_permalink';
                 }
             }
-        endif;
+        }
 
         if ( isset( $function ) && isset( $id ) ) {
             // parse all languages links

--- a/src/modules/slugs/slugs.php
+++ b/src/modules/slugs/slugs.php
@@ -437,8 +437,9 @@ class QTX_Module_Slugs {
                     $function = 'get_post_type_archive_link';
                     $id       = $query['post_type'];
                 } else {
-                    $page_slug = ( isset( $query['name'] ) && ! empty( $query['name'] ) ) ? $query['name'] : $query[ $query['post_type'] ];
-                    $page      = $this->get_page_by_path( $page_slug, $query['post_type'] );
+
+                    $page_slug = $query['name'] ?? $query[ $query['post_type'] ];
+                    $page      = isset( $page_slug ) ? $this->get_page_by_path( $page_slug, $query['post_type'] ) : null;
                     if ( $page ) {
                         $id          = $page->ID;
                         $cache_array = array( $page );
@@ -452,8 +453,8 @@ class QTX_Module_Slugs {
             // -> taxonomy
             foreach ( $this->get_public_taxonomies() as $item ) {
                 if ( isset( $query[ $item->name ] ) ) {
-                    $term_slug = $this->get_last_slash( empty( $query[ $item->name ] ) ? $wp->request : $query[ $item->name ] );
-                    $term      = $this->get_term_by( 'slug', $term_slug, $item->name );
+                    $term_slug = $this->get_last_slash( $query[ $item->name ] ?? $wp->request );
+                    $term      = isset( $term_slug ) ? $this->get_term_by( 'slug', $term_slug, $item->name ) : null;
                     if ( $term ) {
                         $cache_array = array( $term );
                         update_term_cache( $cache_array, $item->name ); // caching query :)

--- a/src/modules/slugs/slugs.php
+++ b/src/modules/slugs/slugs.php
@@ -43,8 +43,7 @@ class QTX_Module_Slugs {
 
         // remove from qtranslate the discouraged meta http-equiv, inline styles
         // (including flag URLs) and wrong hreflang links
-        remove_action( 'wp_head', 'qtranxf_wp_head' ); //TODO: check if it is needed, and why it is not in the main plugin in case
-
+        remove_action( 'wp_head', 'qtranxf_wp_head' );
         // add proper hreflang links
         add_action( 'wp_head', array( &$this, 'head_hreflang' ) );
 
@@ -71,22 +70,29 @@ class QTX_Module_Slugs {
 
     /**
      * Adds proper links to the content with available translations.
-     * Fixes issue #25
+     * This function is mostly same as qtranxf_wp_head() except for the functions
+     * used to retrieve the href links.
      *
      * @global QtranslateSlug $qtranslate_slugs used to convert the url
      * @global array $q_config available languages
+     * @see qtranxf_wp_head()
      */
     public function head_hreflang() {
         global $q_config;
+
         if ( is_404() ) {
             return;
         }
-        //TODO: double check following comment:
-        // taken from qtx but see our #341 ticket for clarification
-        echo '<link hreflang="x-default" href="' . esc_url( $this->get_current_url( $q_config['default_language'] ) ) . '" rel="alternate" />' . PHP_EOL;
-        foreach ( $q_config['enabled_languages'] as $language ) {
 
-            echo '<link hreflang="' . $language . '" href="' . esc_url( $this->get_current_url( $language ) ) . '" rel="alternate" />' . "\n";
+        $hreflangs = array();
+        foreach ( $q_config['enabled_languages'] as $lang ) {
+            $hreflang = ! empty ( $q_config['locale_html'][ $lang ] ) ? $q_config['locale_html'][ $lang ] : $lang;
+            $hreflangs[ $hreflang ] = esc_url( $this->get_current_url( $lang ) );
+        }
+        $hreflangs['x-default'] = esc_url( $this->get_current_url( $q_config['default_language'] ) );
+
+        foreach ( $hreflangs as $hreflang => $href ) {
+            echo '<link hreflang="' . $hreflang . '" href="' . $href . '" rel="alternate" />' . PHP_EOL;
         }
     }
 

--- a/src/modules/slugs/slugs.php
+++ b/src/modules/slugs/slugs.php
@@ -43,7 +43,6 @@ class QTX_Module_Slugs {
 
         // remove from qtranslate the discouraged meta http-equiv, inline styles
         // (including flag URLs) and wrong hreflang links
-        remove_action( 'wp_head', 'qtranxf_header' ); //TODO: check if it is needed, and why it is not in the main plugin in case
         remove_action( 'wp_head', 'qtranxf_wp_head' ); //TODO: check if it is needed, and why it is not in the main plugin in case
 
         // add proper hreflang links


### PR DESCRIPTION
Bunch of fixes for slugs module:
- Slugs: fix possible null passed to filter_request functions
Fixes #1358 

- Slugs: filter_request() reformatting and cleanup

- Slugs: use 'Locale at front-end' if available as hreflang
Fixes #1359 

- Slugs: remove reference to obsolete hook

- Slugs: fix home_url to handle 'rest' and 'relative' schemes
This is needed to fix wrong result in case of 'relative' scheme argument request, being currently returned the entire 'http/https' anyways.
Fixes #1373 
Fixes #1273

- Slugs: restore original query if filter_request() fails
In case filter_request is not able to identify an handling function, original query needs to be provided (including the 404 flag previously stripped)