### PR TITLE
[SLUGS] fix language autodetection

### DIFF
--- a/src/init.php
+++ b/src/init.php
@@ -82,6 +82,8 @@ function qtranxf_init_language(): void {
     $url_info['language'] = qtranxf_detect_language( $url_info );
     $q_config['language'] = apply_filters( 'qtranslate_language', $url_info['language'], $url_info );
 
+    QTX_Module_Loader::load_active_modules_early_hooks();
+
     assert( isset( $q_config['url_info']['doing_front_end'] ) );
     if ( $q_config['url_info']['doing_front_end'] && qtranxf_can_redirect() ) {
         qtranxf_check_url_maybe_redirect( $url_info );

--- a/src/modules/module_loader.php
+++ b/src/modules/module_loader.php
@@ -39,4 +39,24 @@ class QTX_Module_Loader {
             }
         }
     }
+
+    /**
+     * Loads early hooks from modules previously activated in the options.
+     *
+     * Attention! This assumes the current states stored in the options are valid.
+     * This doesn't perform any check, neither on the plugin conditions nor the folder structure.
+     * In the worst case the state can be refreshed by reactivating the plugin.
+     *
+     * Note also the modules should be loaded before "qtranslate_init_language" is triggered.
+     */
+    public static function load_active_modules_early_hooks(): void {
+        $modules_state = get_option( QTX_OPTIONS_MODULES_STATE, array() );
+
+        foreach ( $modules_state as $module_id => $state ) {
+            $target = QTRANSLATE_DIR . '/src/modules/' . $module_id . '/' . 'early_hooks.php';
+            if ( $state === QTX_MODULE_STATE_ACTIVE && file_exists( $target ) ) {
+                require_once( $target );
+            }
+        }
+    }
 }

--- a/src/modules/slugs/early_hooks.php
+++ b/src/modules/slugs/early_hooks.php
@@ -1,0 +1,27 @@
+<?php
+
+add_filter( 'qtranslate_language_detect_redirect', 'qtranxf_slugs_language_detect_redirect', 600, 3 );
+
+/**
+* Allows url redirection due to language auto detection only if site url has been requested
+*
+* @see qtranxf_check_url_maybe_redirect
+* @param string $url_lang proposed target URL for the active language to redirect to.
+* @param string $url_orig original URL supplied to browser, which needs to be standardized.
+* @param array $url_info a hash of various information parsed from original URL, cookies and other site configuration. The key names should be self-explanatory.
+*
+* @return string resulting redirection url
+*/
+function qtranxf_slugs_language_detect_redirect($url_lang, $url_orig, $url_info): string {
+   global $q_config;
+   if (site_url().'/' === $url_orig)
+       return $url_lang;
+   else {
+       if ( empty( $url_info['lang_url'] ) ){
+           return qtranxf_convertURL( $url_orig, $q_config['default_language'],false,true );
+       } else {
+           return $url_orig;
+       }
+   }
+}
+


### PR DESCRIPTION
Uses the [qtranslate_language_detect_redirect](https://github.com/qtranslate/qtranslate-xt/blob/9816c7690c287f7887ac5a42b48666dd18f3d0a7/src/language_detect.php#L456) filter to change default QTX redirection behaviour, redirecting user url only if `site_url()` is requested and not redirecting otherwise. In the latter case, if `$url_info['lang_url']` is empty default language is assumed.
To use `qtranslate_language_detect_redirect` filter, placed in QTX source before modules are loaded, additional modules "early hooks" mechanism has been added to modules handling.

Fixes #1328 
Fixes #1348 
May help with #1273 