### PR TITLE
Fix wp-cli incompatibility 

### DIFF
--- a/qtranslate.php
+++ b/qtranslate.php
@@ -65,7 +65,7 @@ if ( ! defined( 'QTRANSLATE_FILE' ) ) {
 require_once QTRANSLATE_DIR . '/src/init.php';
 add_action( 'plugins_loaded', 'qtranxf_init_language', 2 ); // User is not authenticated yet, high priority needed.
 
-if ( is_admin() ) {
+if ( is_admin() || defined( 'WP_CLI' ) ) {
     require_once QTRANSLATE_DIR . '/src/admin/activation_hook.php';
     qtranxf_register_activation_hooks();
 }


### PR DESCRIPTION
As mentioned in qtranslate/qtranslate-xt#1344 the plugin is incompatible with wp-cli.

For example, the following command fails:

    wp-cli plugin activate qtranslate-xt

Any action with wp-cli results in an error such as the one below, where functions haven't been defined.

    call_user_func(): Argument #1 ($callback) must be a valid callback

In my case the missing function happened to be `function "qtranxf_default_default_language" not found`.

The reason for this, is the functions were defined in `/src/admin/activation_hook.php` which isn't included when the WP function `is_admin()` returns false, as it does in wp-cli. Any user who has access to the wp-cli binary clearly has administrative privileges over the installation, so not including those function definitions is presumably not the intended behviour. 

This pull request ensures those functions have been defined if the `WP_CLI` php const is defined, fixing compatibility with wp-cli.