### PR TITLE
Detailed instructions to migrate Slugs from legacy

### DIFF
--- a/src/modules/slugs/README.md
+++ b/src/modules/slugs/README.md
@@ -17,12 +17,18 @@ If you want to translate also the base permastructs (ex. *category*, *tag*, etc)
 - Set the base permastructs for **post types** and **taxonomies** (If you setup a base permastruct for *categories* or *tags* in *Settings/Permalinks*, these will be overwritten by the translated ones).
 - Save settings and that's all!
 
-### I've been using the QTS plugin, how can I find the existing slugs?
-Enable the *Slugs* module, go in the "Import" settings of qTranslate and import QTS data.
-The dry-run mode allows to test the import and see the number of rows changed before updating the database.
+### How can I migrate from the legacy QTS plugin to the new module?
+If you are migrating from using *qTranslate X* and the *qtranslate-slug* (QTS) plugin, migration should work with this sequence:
 
-**Attention!** Do not uninstall QTS before migrating data to qTranslate, it deletes data permanently.
-Once the migration is done, the data is not be visible in QTS anymore and the QTS plugin can be uninstalled.
+1. Make sure that you are on **latest version of the legacy plugin**
+2. **Deactivate the legacy plugin**
+3. **Activate the *Slugs* module**
+4. **Migrate** using `Migrate QTS slugs` in *QTX Settings > Import/Export*. The dry-run mode allows to test the import and see the number of rows changed before updating the database.
+5. **Delete the legacy plugin**
+
+If you are using functions from the legacy plugin in your theme files, you may want to switch to a neutral theme.
+
+**Attention!** Do not uninstall QTS before migrating data to qTranslate, it deletes data permanently. Once the migration is done, the data is not be visible in QTS anymore and the QTS plugin can be uninstalled.
 
 ### I get a 404 error, what can I do?
 In the admin go to *Settings/Permalinks* or *Settings/Languages* (qTranslate) options and save.


### PR DESCRIPTION
Some extra instructions to migrate Slugs from the legacy plugin, after having some issues and getting help from one of the maintaners, @spleen1981.

Discussion can be followed here: https://github.com/qtranslate/qtranslate-xt/discussions/1401#discussioncomment-8950469