### PR TITLE
fix missing menu_items with no translation

### DIFF
--- a/src/frontend.php
+++ b/src/frontend.php
@@ -106,6 +106,9 @@ function qtranxf_wp_get_nav_menu_items( $items, $menu, $args ) {
                             $term = wp_cache_get( $item->object_id, $item->object );
                             if ( $term ) {
                                 $item_title = $q_config['term_name'][ $term->name ][ $language ] ?? '';
+                                 if ($item_title == '' && $q_config['show_menu_alternative_language']) {
+                                	$item_title = $item->title;
+                                }
                                 if ( ! empty( $term->description ) ) {
                                     $item->description = $term->description;
                                 }


### PR DESCRIPTION
Prevent menu items (taxonomy) being removed from menus when the term title is the same as the default language and the options "Show menu items in an alternative language when translation is not available for the selected language." is selected.