### PR TITLE
Issue-1422: Load the text domain using the "init" hook

### DIFF
--- a/qtranslate.php
+++ b/qtranslate.php
@@ -63,7 +63,7 @@ if ( ! defined( 'QTRANSLATE_FILE' ) ) {
 }
 
 require_once QTRANSLATE_DIR . '/src/init.php';
-add_action( 'plugins_loaded', 'qtranxf_init_language', 2 ); // User is not authenticated yet, high priority needed.
+add_action( 'init', 'qtranxf_init_language', 2 );
 
 if ( is_admin() ) {
     require_once QTRANSLATE_DIR . '/src/admin/activation_hook.php';


### PR DESCRIPTION
Fixes this WordPress warning: 

> PHP Notice:  Function _load_textdomain_just_in_time was called <strong>incorrectly</strong>. Translation loading for the <code>qtranslate</code> domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the <code>init</code> action or later.

I removed the comment regarding the user not being authenticated because the user is authenticated when the "init" hook fires. 

https://developer.wordpress.org/reference/hooks/init/