### PR TITLE
Bump PHP minimum requirement to 7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Contributors: herrvigg, johnclause, chineseleper, Vavooon, grafcom
 Tags: multilingual, language, admin, tinymce, bilingual, widget, switcher, i18n, l10n, multilanguage, translation  
 Requires at least: 5.0  
 Tested up to: 6.7.2  
-Requires PHP: 7.1  
+Requires PHP: 7.3  
 Stable tag: N/A  
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
   },
   "require": {
     "composer/installers": ">=1.0",
-    "php": ">=7.1",
+    "php": ">=7.3",
     "ext-intl": "*"
   },
   "extra": {

--- a/qtranslate.php
+++ b/qtranslate.php
@@ -5,7 +5,7 @@
  * Description: Adds user-friendly multilingual content support, stored in single post.
  * Version: 3.15.3
  * Requires at least: 5.0
- * Requires PHP: 7.1
+ * Requires PHP: 7.3
  * Author: qTranslate Community
  * Author URI: https://github.com/qtranslate/
  * Tags: multilingual, multi, language, admin, tinymce, Polyglot, bilingual, widget, switcher, professional, human, translation, service, qTranslate, zTranslate, mqTranslate, qTranslate Plus, WPML
@@ -55,7 +55,7 @@ if ( ! function_exists( 'add_filter' ) ) {
  * The constants defined below are designed as interface for other plugin integration.
  * @see https://github.com/qtranslate/qtranslate-xt/wiki/Integration-Guide/
  */
-const QTX_VERSION = '3.15.3';
+const QTX_VERSION = '3.16.0.dev.0';
 
 if ( ! defined( 'QTRANSLATE_FILE' ) ) {
     define( 'QTRANSLATE_FILE', __FILE__ );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: herrvigg, johnclause, chineseleper, Vavooon, grafcom
 Tags: multilingual, language, admin, tinymce, bilingual, widget, switcher, i18n, l10n, multilanguage, translation
 Requires at least: 5.0
 Tested up to: 6.7.2
-Requires PHP: 7.1
+Requires PHP: 7.3
 Stable tag: N/A
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/src/admin/activation_hook.php
+++ b/src/admin/activation_hook.php
@@ -754,10 +754,10 @@ function qtranxf_clear_debug_log(): void {
 
 function qtranxf_activation_hook(): void {
     qtranxf_clear_debug_log();
-    if ( version_compare( PHP_VERSION, '7.1' ) < 0 ) {
+    if ( version_compare( PHP_VERSION, '7.3' ) < 0 ) {
         // Deactivate ourself
         load_plugin_textdomain( 'qtranslate', false, basename( QTRANSLATE_DIR ) . '/lang' );
-        $msg = sprintf( __( 'Plugin %s requires PHP version %s at least. This server instance runs PHP version %s. A PHP version %s or higher is recommended. The plugin has not been activated.', 'qtranslate' ), qtranxf_get_plugin_link(), '7.1', PHP_VERSION, '8.2' );
+        $msg = sprintf( __( 'Plugin %s requires PHP version %s at least. This server instance runs PHP version %s. A PHP version %s or higher is recommended. The plugin has not been activated.', 'qtranslate' ), qtranxf_get_plugin_link(), '7.3', PHP_VERSION, '8.4' );
         deactivate_plugins( plugin_basename( QTRANSLATE_FILE ) );
         wp_die( $msg );
     }

--- a/src/language_detect.php
+++ b/src/language_detect.php
@@ -342,19 +342,13 @@ function qtranxf_setcookie_language( string $lang, string $cookie_name, string $
         return;
     }
 
-    // SameSite only available with options API from PHP 7.3.0
-    if ( version_compare( PHP_VERSION, '7.3.0' ) >= 0 ) {
-        setcookie( $cookie_name, $lang, [
-            'expires'  => strtotime( '+1year' ),
-            'path'     => $cookie_path,
-            'secure'   => $q_config['use_secure_cookie'],
-            'httponly' => true,
-            'samesite' => QTX_COOKIE_SAMESITE
-        ] );
-    } else {
-        // only meant for server-side, set 'httponly' flag
-        setcookie( $cookie_name, $lang, strtotime( '+1year' ), $cookie_path, null, $q_config['use_secure_cookie'], true );
-    }
+    setcookie( $cookie_name, $lang, [
+        'expires'  => strtotime( '+1year' ),
+        'path'     => $cookie_path,
+        'secure'   => $q_config['use_secure_cookie'],
+        'httponly' => true,
+        'samesite' => QTX_COOKIE_SAMESITE
+    ] );
 }
 
 function qtranxf_set_language_cookie( string $lang ): void {


### PR DESCRIPTION
The recommended version becomes PHP 8.4.
PHP 7.4 has reached end of life support in 2022.
PHP 8.0 has reached end of life support in 2023.
The short-term goal is to bump to minimum PHP 8.1 gradually.