### PR TITLE
Fix Raw ML term names when i18n config is already initialized

### DIFF
--- a/src/admin/admin_taxonomy.php
+++ b/src/admin/admin_taxonomy.php
@@ -21,18 +21,18 @@ function qtranxf_term_name_encoded( string $name ): string {
 
 function qtranxf_get_term_joined( $obj, ?string $taxonomy = null ) {
     global $q_config;
+
     if ( is_object( $obj ) ) {
-        // WP_Term object conversion
         if ( ! isset( $obj->i18n_config ) ) {
             qtranxf_term_set_i18n_config( $obj );
-            if ( isset( $obj->i18n_config['name']['ts'] ) ) {
-                $ml        = qtranxf_join_b( $obj->i18n_config['name']['ts'] );
-                $obj->name = $obj->i18n_config['name']['ml'] = $ml;
-            }
+        }
+
+        if ( isset( $obj->i18n_config['name']['ts'] ) ) {
+            $ml = qtranxf_join_b( $obj->i18n_config['name']['ts'] );
+            $obj->name = $obj->i18n_config['name']['ml'] = $ml;
         }
     } elseif ( isset( $q_config['term_name'][ $obj ] ) ) {
         $obj = qtranxf_join_b( $q_config['term_name'][ $obj ] );
-        // TODO dead code? we probably do not need it
     }
 
     return $obj;


### PR DESCRIPTION
Fix `qtranxf_get_term_joined()` so that it always restores the complete Raw ML term name from the language values stored in `i18n_config['name']['ts']`.

Previously, the Raw ML value was rebuilt only when `i18n_config` had not yet been initialized. If the term object already contained `i18n_config`, its `name` property could remain translated into the currently active language instead of containing the complete multilingual value.

This caused taxonomy term fields in the WordPress admin to display only one language after saving, for example:

`Wallpapers`

instead of:

`[:en]Wallpapers[:uk]Шпалери[:]`

The updated function initializes `i18n_config` when necessary and then independently rebuilds both:

`
$obj->name
$obj->i18n_config['name']['ml']
`

from `i18n_config['name']['ts']`.

The issue became visible after updating WordPress from 6.8.5 to 7.0.