### PR TITLE
Fix woocommerce object cache

### DIFF
--- a/src/modules/woo-commerce/front.php
+++ b/src/modules/woo-commerce/front.php
@@ -3,10 +3,27 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+/**
+ * Translate product terms after WooCommerce retrieves them from cache.
+ *
+ * WooCommerce product-term cache keys do not include the current language,
+ * so a persistent object cache may return terms translated during an
+ * earlier request in another language.
+ *
+ * @param array $terms Product terms.
+ *
+ * @return array
+ */
+function qtranxf_wc_translate_product_terms( $terms ) {
+    return qtranxf_useTermLib( $terms );
+}
+
 function qtranxf_wc_add_filters_front(): void {
 
     remove_filter( 'get_post_metadata', 'qtranxf_filter_postmeta', 5 );
     add_filter( 'get_post_metadata', 'qtranxf_wc_filter_postmeta', 5, 4 );
+
+    add_filter( 'woocommerce_get_product_terms', 'qtranxf_wc_translate_product_terms', 20, 1 );
 
     $front_hooks = array(
         'woocommerce_attribute'                       => 20,

--- a/src/modules/woo-commerce/loader.php
+++ b/src/modules/woo-commerce/loader.php
@@ -7,6 +7,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 function qtranxf_wc_init_language( array $url_info ): void {
+    /*
+     * WooCommerce caches the filtered result of
+     * `woocommerce_attribute_taxonomies`. Since qTranslate-XT translates
+     * this result, a persistent object cache would store the language of
+     * the first request for all subsequent requests.
+     */
+    if ( function_exists( 'wp_cache_add_non_persistent_groups' ) ) {
+        wp_cache_add_non_persistent_groups( array( 'woocommerce-attributes' ) );
+    }
+
     if ( $url_info['doing_front_end'] ) {
         require_once __DIR__ . '/front.php';
     } else {

--- a/src/taxonomy.php
+++ b/src/taxonomy.php
@@ -33,24 +33,28 @@ function qtranxf_term_set_i18n_config( $term ) {
  */
 function qtranxf_term_use( string $lang, $obj, $taxonomy ) {
     global $q_config;
+
     if ( is_array( $obj ) ) {
-        // handle arrays recursively
+        // Handle arrays recursively.
         foreach ( $obj as $key => $term ) {
             $obj[ $key ] = qtranxf_term_use( $lang, $term, $taxonomy );
         }
 
         return $obj;
     }
+
     if ( is_object( $obj ) ) {
-        // object conversion
         if ( ! isset( $obj->i18n_config ) ) {
             qtranxf_term_set_i18n_config( $obj );
-            if ( isset( $obj->i18n_config['name']['ts'][ $lang ] ) ) {
-                $obj->name = $obj->i18n_config['name']['ts'][ $lang ];
-            }
-            if ( isset( $obj->i18n_config['description']['ts'][ $lang ] ) ) {
-                $obj->description = $obj->i18n_config['description']['ts'][ $lang ];
-            }
+        }
+
+        if ( isset( $obj->i18n_config['name']['ts'][ $lang ] ) ) {
+            $obj->name = $obj->i18n_config['name']['ts'][ $lang ];
+        }
+
+        if ( isset( $obj->i18n_config['description']['ts'][ $lang ] ) ) {
+            $obj->description =
+                $obj->i18n_config['description']['ts'][ $lang ];
         }
     } elseif ( isset( $q_config['term_name'][ $obj ][ $lang ] ) ) {
         $obj = $q_config['term_name'][ $obj ][ $lang ];


### PR DESCRIPTION
## Description

Fixes WooCommerce attribute labels and values being displayed in the language of the first request when a persistent object cache is enabled.

WooCommerce cache keys for attribute taxonomies and product terms do not include the current qTranslate-XT language. As a result, translated data may be stored and reused for other languages.

## Changes

- Exclude the `woocommerce-attributes` group from persistent object caching.
- Translate product terms after WooCommerce retrieves them from cache.
- Reapply the requested language to term objects that already contain `i18n_config`.

## Testing

Tested with WooCommerce and LiteSpeed Object Cache using Memcached.

Verified that product attribute labels and term values switch correctly between Russian and Ukrainian after clearing and rebuilding the object cache.